### PR TITLE
[FOGL-1833] removed (required) depdency of postgresql and postgres c lib 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,6 +44,17 @@ The make_deb Script
    cleanall - Remove all the versions, including the last one
   $
 
+.. warning::
+
+  Postgres dependencies will not be installed automatically.
+  In order to use postgres storage engine, you will need manual installation of `libpq-dev` and `postgresql`.
+
+    .. code-block:: console
+
+       yes Y | sudo apt install libpq-dev
+       yes Y | sudo apt install postgresql
+
+
 
 Building a Package
 ==================

--- a/README.rst
+++ b/README.rst
@@ -47,11 +47,10 @@ The make_deb Script
 .. warning::
 
   Postgres dependencies will not be installed automatically.
-  In order to use postgres storage engine, you will need manual installation of `libpq-dev` and `postgresql`.
+  In order to use postgres storage engine, you will need manual installation of `postgresql`.
 
     .. code-block:: console
 
-       yes Y | sudo apt install libpq-dev
        yes Y | sudo apt install postgresql
 
 

--- a/packages/Debian/armhf/DEBIAN/control
+++ b/packages/Debian/armhf/DEBIAN/control
@@ -3,7 +3,7 @@ Version: 1.0.0
 Section: devel
 Priority: optional
 Architecture: armhf
-Depends: autoconf,libtool,libboost-dev,libboost-system-dev,libboost-thread-dev,libpq-dev,postgresql,python3-pip,python3-setuptools,sqlite3
+Depends: autoconf,libtool,libboost-dev,libboost-system-dev,libboost-thread-dev,python3-pip,python3-setuptools,sqlite3
 Conflicts:
 Maintainer: Dianomic Systems, Inc. <info@dianomic.com>
 Homepage: http://www.dianomic.com

--- a/packages/Debian/armhf/DEBIAN/control
+++ b/packages/Debian/armhf/DEBIAN/control
@@ -3,7 +3,7 @@ Version: 1.0.0
 Section: devel
 Priority: optional
 Architecture: armhf
-Depends: autoconf,libtool,libboost-dev,libboost-system-dev,libboost-thread-dev,python3-pip,python3-setuptools,sqlite3
+Depends: autoconf,libtool,libboost-dev,libboost-system-dev,libboost-thread-dev,libpq-dev,python3-pip,python3-setuptools,sqlite3
 Conflicts:
 Maintainer: Dianomic Systems, Inc. <info@dianomic.com>
 Homepage: http://www.dianomic.com

--- a/packages/Debian/x86_64/DEBIAN/control
+++ b/packages/Debian/x86_64/DEBIAN/control
@@ -3,7 +3,7 @@ Version: 1.0.0
 Section: devel
 Priority: optional
 Architecture: amd64
-Depends: autoconf,curl,libtool,libboost-dev,libboost-system-dev,libboost-thread-dev,libpq-dev,postgresql,python3-pip,python3-setuptools,sqlite3
+Depends: autoconf,curl,libtool,libboost-dev,libboost-system-dev,libboost-thread-dev,python3-pip,python3-setuptools,sqlite3
 Conflicts:
 Maintainer: Dianomic Systems, Inc. <info@dianomic.com>
 Homepage: http://www.dianomic.com

--- a/packages/Debian/x86_64/DEBIAN/control
+++ b/packages/Debian/x86_64/DEBIAN/control
@@ -3,7 +3,7 @@ Version: 1.0.0
 Section: devel
 Priority: optional
 Architecture: amd64
-Depends: autoconf,curl,libtool,libboost-dev,libboost-system-dev,libboost-thread-dev,python3-pip,python3-setuptools,sqlite3
+Depends: autoconf,curl,libtool,libboost-dev,libboost-system-dev,libboost-thread-dev,libpq-dev,python3-pip,python3-setuptools,sqlite3
 Conflicts:
 Maintainer: Dianomic Systems, Inc. <info@dianomic.com>
 Homepage: http://www.dianomic.com


### PR DESCRIPTION
FogLAMP package requires/installs postgres, it should not; as default plugin is sqlite.
