### PR TITLE
FOGL-1751: allow postinst script to call update script

### DIFF
--- a/packages/Debian/common/DEBIAN/postinst
+++ b/packages/Debian/common/DEBIAN/postinst
@@ -83,7 +83,7 @@ call_package_update_script () {
         current_installed_version=`cat ${installed_version_file}`
         update_script="/usr/local/foglamp/scripts/package/debian/package_update.sh"
         # Check update script exists
-        if [ -x "${update_script}" ] && [ -s "${update_script}" ]; then
+        if [ -x "${update_script}" ] && [ -s "${update_script}" ] && [ -O "${update_script}" ]; then
             # Call Debian update script passing the previous version
             ${update_script} ${current_installed_version}
         fi

--- a/packages/Debian/common/DEBIAN/postinst
+++ b/packages/Debian/common/DEBIAN/postinst
@@ -21,7 +21,7 @@
 ## @postinst DEBIAN/postinst
 ## This script is used to execute post installation tasks.
 ##
-## Author: Ivan Zoratti
+## Author: Ivan Zoratti, Massimiliano Pinto
 ##
 ##--------------------------------------------------------------------
 
@@ -74,6 +74,24 @@ install_pip3_packages () {
     pip3 install -r /usr/local/foglamp/python/requirements.txt
 }
 
+# Call FogLAMP package update script
+# Any message will be written by called update script
+call_package_update_script () {
+    # File created by presinstall hook
+    installed_version_file="/usr/local/foglamp/.current_installed_version"
+    if [ -s "${installed_version_file}" ]; then
+        current_installed_version=`cat ${installed_version_file}`
+        update_script="/usr/local/foglamp/scripts/package/debian/package_update.sh"
+        # Check update script exists
+        if [ -x "${update_script}" ] && [ -s "${update_script}" ]; then
+            # Call Debian update script passing the previous version
+            ${update_script} ${current_installed_version}
+        fi
+        # Update done: remove temp file
+        rm ${installed_version_file}
+    fi
+}
+
 # main
 echo "Install python dependencies"
 install_pip3_packages
@@ -85,6 +103,10 @@ echo "Generating certificate files"
 generate_certs
 echo "Setting ownership of FogLAMP files"
 set_files_ownership
+
+# Call FogLAMP package update script
+call_package_update_script
+
 echo "Enabling FogLAMP service"
 enable_foglamp_service
 echo "Starting FogLAMP service"

--- a/packages/Debian/common/DEBIAN/preinst
+++ b/packages/Debian/common/DEBIAN/preinst
@@ -21,7 +21,7 @@
 ## @preinst DEBIAN/preinst
 ## This script is used to execute pre installation tasks.
 ##
-## Author: Ivan Zoratti, Ashwin Gopalakrishnan
+## Author: Ivan Zoratti, Ashwin Gopalakrishnan, Massimiliano Pinto
 ##
 ##--------------------------------------------------------------------
 
@@ -83,7 +83,18 @@ then
         echo "*** ERROR. FogLAMP is currently running. Stop FogLAMP and try again. ***"
         exit 1
     fi
-    
+
+    # Persist current version in case of upgrade/downgrade
+    installed_version=`dpkg -s ${PKG_NAME} | grep '^Version:' | awk '{print $2}'`
+    if [ "${installed_version}" ]
+    then
+        # Persist current FogLAMP version: it will be removed by postinstall script
+        this_dir=`pwd`
+        cd usr/local/foglamp/
+        echo "${installed_version}" > .current_installed_version
+        cd ${this_dir}
+    fi
+
     # check schema version file, exit if schema change path does not exist
     CURRENT_VERSION_FILE=$(get_current_version_file)
     CURRENT_SCHEMA_VERSION=$(get_schema_version $CURRENT_VERSION_FILE)


### PR DESCRIPTION
preinst script saves a temporary file with current installed FogLAMP debian package version.

postinst script calls FogLAMP Debian script update /usr/local/foglamp/scripts/package/debian/package_update.sh passing the previous version.

Temporary file is removed after the script call.

The /usr/local/foglamp/scripts/package/debian/package_update.sh performs all needed upgrade/downgrade actions based on scripts found in:
- /usr/local/foglamp/scripts/package/debian/upgrade/*.sh
- /usr/local/foglamp/scripts/package/debian/downgrade/*.sh

These scripts weill be added into FogLAMP repository