### PR TITLE
FOGL-2756: RPM packaging for FogLAMP core

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -122,7 +122,7 @@ The make_rpm Script
 ===================
 .. code-block:: console
 
-  $ ./make_prm --help
+  $ ./make_rpm --help
   make_rpm help [clean|cleanall]
   This script is used to create the RPM package of FogLAMP
   Arguments:
@@ -136,11 +136,11 @@ Building a RPM Package
 
 First, make sure that FogLAMP is properly installed via ``make install`` somewhere on your environment (default is */usr/local/foglamp*).
 Next, *x86* is the only currently supported architecture for RedHat/Centos.
-Finally, run the ``make_prm`` command:
+Finally, run the ``make_rpm`` command:
 
 .. code-block:: console
 
-  $ ./make_prm
+  $ ./make_rpm
   The package root directory is : /home/foglamp/repos/foglamp-pkg
   The FogLAMP directory is      : /home/foglamp/foglamp
   The FogLAMP version is        : 1.5.2

--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ Internal Structure
 The repository contains the following set of files:
 
 - Files named with **make_** prefix, such as ``make_deb``, are the shell scripts used to build the package. The scripts accept the architecture to build as argument (currently *x86* and *arm*).
-- The **packages** folder contains the list package types to build. At the moment, the only package type we provide is *Debian*.
+- The **packages** folder contains the list package types to build. It contains *Debian* and *rpmbuild*, latter for RedHat/Centos RPM creation.
 
   - Inside the *packages/Debian* folder, we have the **architecture** folders, plus a *common* folder containing files that are common to all the architectures. The architectures that we provide at the moment are *armhf* and *x86_64*.
 
@@ -55,8 +55,8 @@ The make_deb Script
 
 
 
-Building a Package
-==================
+Building a Debian Package
+=========================
 
 First, make sure that FogLAMP is properly installed via ``make install`` somewhere on your environment (default is */usr/local/foglamp*).
 Next, select the architecture to use, *x86* or *arm*.
@@ -116,6 +116,97 @@ If you execute the ``make_deb`` command again, you will see:
   $
    
 ... where the previous build is now marked with the suffix *.0001*.
+
+
+The make_rpm Script
+===================
+.. code-block:: console
+
+  $ ./make_prm --help
+  make_rpm help [clean|cleanall]
+  This script is used to create the RPM package of FogLAMP
+  Arguments:
+   help     - Display this help text
+   clean    - Remove all the old versions saved in format .XXXX
+   cleanall - Remove all the versions, including the last one
+  $
+
+Building a RPM Package
+======================
+
+First, make sure that FogLAMP is properly installed via ``make install`` somewhere on your environment (default is */usr/local/foglamp*).
+Next, *x86* is the only currently supported architecture for RedHat/Centos.
+Finally, run the ``make_prm`` command:
+
+.. code-block:: console
+
+  $ ./make_prm
+  The package root directory is : /home/foglamp/repos/foglamp-pkg
+  The FogLAMP directory is      : /home/foglamp/foglamp
+  The FogLAMP version is        : 1.5.2
+  The package will be built in  : /home/foglamp/repos/foglamp-pkg/packages/rpmbuild/RPMS/x86_64
+  The package name is           : foglamp-1.5.2-0.00.x86_64
+
+  Saving the old working environment as foglamp-1.5.2-0.00.x86_64.0077
+  Populating the package and updating version in control file...Done.
+  Prepare data directory
+  Saving the old package as foglamp-1.5.2-0.00.x86_64.rpm.0001
+  Building the new package...
+  Processing files: foglamp-1.5.2-0.00.x86_64
+  Provides: foglamp = 1.5.2-0.00 foglamp(x86-64) = 1.5.2-0.00
+  Requires(interp): /bin/sh /bin/sh /bin/sh
+  Requires(rpmlib): rpmlib(FileDigests) <= 4.6.0-1 rpmlib(PayloadFilesHavePrefix) <= 4.0-1 rpmlib(CompressedFileNames) <= 3.0.4-1
+  Requires(pre): /bin/sh
+  Requires(post): /bin/sh
+  Requires(preun): /bin/sh
+  Checking for unpackaged file(s): /usr/lib/rpm/check-files /home/foglamp/repos/foglamp-pkg/packages/rpmbuild/BUILDROOT/foglamp-1.5.2-0.00.x86_64
+  Wrote: /home/foglamp/repos/foglamp-pkg/packages/rpmbuild/RPMS/x86_64/foglamp-1.5.2-0.00.x86_64.rpm
+  Building Complete.
+  $
+
+The result will be:
+
+.. code-block:: console
+
+  $ ls -l packages/rpmbuild/RPMS/x86_64
+  total 6444
+  -rw-rw-r-- 1 foglamp foglamp 6597376 May 10 02:08 foglamp-1.5.2-0.00.x86_64.rpm
+  $
+
+If you execute the ``make_rpm`` command again, you will see:
+
+.. code-block:: console
+
+  $ ./make_rpm
+  The package root directory is : /home/foglamp/repos/foglamp-pkg
+  The FogLAMP directory is      : /home/foglamp/foglamp
+  The FogLAMP version is        : 1.5.2
+  The package will be built in  : /home/foglamp/repos/foglamp-pkg/packages/rpmbuild/RPMS/x86_64
+  The package name is           : foglamp-1.5.2-0.00.x86_64
+
+  Saving the old working environment as foglamp-1.5.2-0.00.x86_64.0079
+  Populating the package and updating version in control file...Done.
+  Prepare data directory
+  Saving the old package as foglamp-1.5.2-0.00.x86_64.rpm.0001
+  Building the new package...
+  Processing files: foglamp-1.5.2-0.00.x86_64
+  Provides: foglamp = 1.5.2-0.00 foglamp(x86-64) = 1.5.2-0.00
+  Requires(interp): /bin/sh /bin/sh /bin/sh
+  Requires(rpmlib): rpmlib(FileDigests) <= 4.6.0-1 rpmlib(PayloadFilesHavePrefix) <= 4.0-1 rpmlib(CompressedFileNames) <= 3.0.4-1
+  Requires(pre): /bin/sh
+  Requires(post): /bin/sh
+  Requires(preun): /bin/sh
+  Checking for unpackaged file(s): /usr/lib/rpm/check-files /home/foglamp/repos/foglamp-pkg/packages/rpmbuild/BUILDROOT/foglamp-1.5.2-0.00.x86_64
+  Wrote: /home/foglamp/repos/foglamp-pkg/packages/rpmbuild/RPMS/x86_64/foglamp-1.5.2-0.00.x86_64.rpm
+  Building Complete.
+  $ ls -l packages/rpmbuild/RPMS/x86_64
+  total 12888
+  -rw-rw-r-- 1 foglamp foglamp 6597420 May 10 02:10 foglamp-1.5.2-0.00.x86_64.rpm
+  -rw-rw-r-- 1 foglamp foglamp 6597376 May 10 02:08 foglamp-1.5.2-0.00.x86_64.rpm.0001
+  $
+
+... where the previous build is now marked with the suffix *.0001*.
+
 
 
 Cleaning the Package Folder

--- a/make_rpm
+++ b/make_rpm
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+##--------------------------------------------------------------------
+## Copyright (c) 2019 OSIsoft, LLC
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##--------------------------------------------------------------------
+##
+## Author: Stefano Simonelli
+##
+
+echo "make rpm"
+
+
+#base_dir=/home/ec2-user/repos/foglamp-pkg/packages
+
+# Develop
+base_dir=/home/foglamp/repos/foglamp-pkg/packages
+
+# Foglamp should be in
+# ${base_dir}/rpmbuild/BUILDROOT/foglamp-1.5.02-0.0.00.x86_64/usr/local/
+
+rpmbuild --define "_topdir ${base_dir}/rpmbuild"   --noclean -bb ${base_dir}/rpmbuild/SPECS/foglamp.spec
+
+ls -l  ${base_dir}/rpmbuild/RPMS/x86_64

--- a/make_rpm
+++ b/make_rpm
@@ -16,20 +16,142 @@
 ## limitations under the License.
 ##--------------------------------------------------------------------
 ##
-## Author: Stefano Simonelli
+## Author: Ivan Zoratti, Ashish Jabble, Stefano Simonelli
 ##
 
-echo "make rpm"
+# FIXME_I
+#set -e
 
+GIT_ROOT=`pwd`    # The script must be executed from the root git directory
 
-#base_dir=/home/ec2-user/repos/foglamp-pkg/packages
+architecture="none"
+usage="$(basename "$0") help [clean|cleanall]
+This script is used to create the RPM package of FogLAMP
+Arguments:
+ help     - Display this help text
+ clean    - Remove all the old versions saved in format .XXXX
+ cleanall - Remove all the versions, including the last one"
 
-# Develop
-base_dir=/home/foglamp/repos/foglamp-pkg/packages
+for i in "$@"
+do
+	case "$i" in
+		clean)
+			echo -n "Cleaning the build folder from older versions..."
+			find "${GIT_ROOT}/packages/rpmbuild/BUILDROOT" -maxdepth 1 | grep '.*\.[0-9][0-9][0-9][0-9]' | xargs rm -rf
+			echo "Done."
+			exit 0
+			;;
+		cleanall)
+			if [ -d "${GIT_ROOT}/packages/rpmbuild/BUILDROOT" ]; then
 
-# Foglamp should be in
-# ${base_dir}/rpmbuild/BUILDROOT/foglamp-1.5.02-0.0.00.x86_64/usr/local/
+				echo -n "Cleaning the build folder..."
+				sudo rm -rf ${GIT_ROOT}/packages/rpmbuild/BUILDROOT/*
+				echo "Done."
+			else
+				echo "No build folder, skipping cleanall"
+			fi
+			exit 0
+			;;
 
+		help)
+			echo "${usage}"
+			exit 0
+			;;
+		*)
+		echo "Unrecognized option: $i"
+		exit 1
+		;;
+	esac
+done
+
+architecture="x86_64"
+
+# If the architecture has not been defined, then the script is complete
+if [[ "$architecture" == "none" ]]; then
+  exit 0
+fi
+
+# Check FOGLAMP_ROOT
+if [ -z ${FOGLAMP_ROOT+x} ]; then
+    # Set FOGLAMP_ROOT as the default directory
+    if [ -d "/usr/local/foglamp" ]; then
+      FOGLAMP_ROOT="/usr/local/foglamp"
+      export FOGLAMP_ROOT
+    else
+      echo "No FOGLAMP_ROOT directory found - Program exit."
+      exit 1
+    fi
+fi
+
+version=`cat ${FOGLAMP_ROOT}/VERSION | tr -d ' ' | grep 'foglamp_version=' | head -1 | sed -e 's/\(.*\)=\(.*\)/\2/g'`
+BUILD_ROOT="${GIT_ROOT}/packages/rpmbuild/BUILDROOT"
+
+# Final package name
+package_name="foglamp-${version}-0.0.00.${architecture}"
+
+# Print the summary of findings
+echo "The package root directory is : ${GIT_ROOT}"
+echo "The FogLAMP directory is      : ${FOGLAMP_ROOT}"
+echo "The FogLAMP version is        : ${version}"
+echo "The package will be built in  : ${BUILD_ROOT}"
+echo "The package name is           : ${package_name}"
+echo
+
+# Create the package directory. If a directory with the same name exists,
+# it is copied with a version number.
+
+# First, create the BUILD_ROOT folder, if necessary
+if [ ! -L "${BUILD_ROOT}" -a ! -d "${BUILD_ROOT}" ]; then
+    mkdir -p "${BUILD_ROOT}"
+fi
+
+cd "${BUILD_ROOT}"
+existing_pkgs=`find . -maxdepth 1 -name "${package_name}.????" | wc -l`
+existing_pkgs=$((existing_pkgs+1))
+new_stored_pkg=$(printf "${package_name}.%04d" "${existing_pkgs}")
+if [ -d "${package_name}" ]; then
+    echo "Saving the old working environment as ${new_stored_pkg}"
+    mv "${package_name}" "${new_stored_pkg}"
+fi
+mkdir "${package_name}"
+
+# Populate the package directory with Debian files
+# First with files common to all pla
+echo -n "Populating the package and updating version in control file..."
+cd "${package_name}"
+sed -i "s/Version: 1.0.0/Version: $version/g" ${GIT_ROOT}/packages/rpmbuild/SPECS/foglamp.spec
+mkdir -p usr/local/foglamp
+cd usr/local/foglamp
+cp -R ${FOGLAMP_ROOT}/* .
+echo "Done."
+
+# Prepare new data directory
+echo "Prepare data directory"
+# FIXME_I
+#mv data data.new
+cd data
+rm -rf core.err
+rm -rf ./etc/certs/*
+rm -rf foglamp.db*
+rm -rf var
+
+# Build the package
+cd "${BUILD_ROOT}"
+cd ..
+cd RPMS
+cd ${architecture}
+
+# Save the old versions
+existing_pkgs=`find . -maxdepth 1 -name "${package_name}.rpm.????" | wc -l`
+existing_pkgs=$((existing_pkgs+1))
+new_stored_pkg=$(printf "${package_name}.rpm.%04d" "${existing_pkgs}")
+
+if [ -e "${package_name}.rpm" ]; then
+    echo "Saving the old package as ${new_stored_pkg}"
+    mv "${package_name}.rpm" "${new_stored_pkg}"
+fi
+
+echo "Building the new package..."
+base_dir=${GIT_ROOT}/packages
 rpmbuild --define "_topdir ${base_dir}/rpmbuild"   --noclean -bb ${base_dir}/rpmbuild/SPECS/foglamp.spec
-
-ls -l  ${base_dir}/rpmbuild/RPMS/x86_64
+echo "Building Complete."

--- a/make_rpm
+++ b/make_rpm
@@ -24,6 +24,9 @@
 
 GIT_ROOT=`pwd`    # The script must be executed from the root git directory
 
+pkg_name="foglamp"
+
+
 architecture="none"
 usage="$(basename "$0") help [clean|cleanall]
 This script is used to create the RPM package of FogLAMP
@@ -87,13 +90,13 @@ version=`cat ${FOGLAMP_ROOT}/VERSION | tr -d ' ' | grep 'foglamp_version=' | hea
 BUILD_ROOT="${GIT_ROOT}/packages/rpmbuild/BUILDROOT"
 
 # Final package name
-package_name="foglamp-${version}-0.0.00.${architecture}"
+package_name="${pkg_name}-${version}-0.00.${architecture}"
 
 # Print the summary of findings
 echo "The package root directory is : ${GIT_ROOT}"
 echo "The FogLAMP directory is      : ${FOGLAMP_ROOT}"
 echo "The FogLAMP version is        : ${version}"
-echo "The package will be built in  : ${BUILD_ROOT}"
+echo "The package will be built in  : ${GIT_ROOT}/packages/rpmbuild/RPMS/${architecture}"
 echo "The package name is           : ${package_name}"
 echo
 
@@ -119,7 +122,11 @@ mkdir "${package_name}"
 # First with files common to all pla
 echo -n "Populating the package and updating version in control file..."
 cd "${package_name}"
-sed -i "s/Version: 1.0.0/Version: $version/g" ${GIT_ROOT}/packages/rpmbuild/SPECS/foglamp.spec
+
+sed -i "s/__NAME__/${pkg_name}/g"     ${GIT_ROOT}/packages/rpmbuild/SPECS/foglamp.spec
+sed -i "s/__VERSION__/${version}/g"   ${GIT_ROOT}/packages/rpmbuild/SPECS/foglamp.spec
+sed -i "s/__ARCH__/${architecture}/g" ${GIT_ROOT}/packages/rpmbuild/SPECS/foglamp.spec
+
 mkdir -p usr/local/foglamp
 cd usr/local/foglamp
 cp -R ${FOGLAMP_ROOT}/* .
@@ -155,3 +162,5 @@ echo "Building the new package..."
 base_dir=${GIT_ROOT}/packages
 rpmbuild --define "_topdir ${base_dir}/rpmbuild"   --noclean -bb ${base_dir}/rpmbuild/SPECS/foglamp.spec
 echo "Building Complete."
+
+exit 0

--- a/make_rpm
+++ b/make_rpm
@@ -19,8 +19,7 @@
 ## Author: Ivan Zoratti, Ashish Jabble, Stefano Simonelli
 ##
 
-# FIXME_I
-#set -e
+set -e
 
 GIT_ROOT=`pwd`    # The script must be executed from the root git directory
 

--- a/make_rpm
+++ b/make_rpm
@@ -89,6 +89,7 @@ version=`cat ${FOGLAMP_ROOT}/VERSION | tr -d ' ' | grep 'foglamp_version=' | hea
 BUILD_ROOT="${GIT_ROOT}/packages/rpmbuild/BUILDROOT"
 
 mkdir -p ${GIT_ROOT}/packages/rpmbuild/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
+mkdir -p ${GIT_ROOT}/packages/rpmbuild/RPMS/x86_64
 
 # Final package name
 package_name="${pkg_name}-${version}-0.00.${architecture}"

--- a/make_rpm
+++ b/make_rpm
@@ -55,7 +55,7 @@ do
 			exit 0
 			;;
 
-		help)
+		--help)
 			echo "${usage}"
 			exit 0
 			;;

--- a/make_rpm
+++ b/make_rpm
@@ -133,8 +133,6 @@ echo "Done."
 
 # Prepare new data directory
 echo "Prepare data directory"
-# FIXME_I
-#mv data data.new
 cd data
 rm -rf core.err
 rm -rf ./etc/certs/*

--- a/make_rpm
+++ b/make_rpm
@@ -88,6 +88,8 @@ fi
 version=`cat ${FOGLAMP_ROOT}/VERSION | tr -d ' ' | grep 'foglamp_version=' | head -1 | sed -e 's/\(.*\)=\(.*\)/\2/g'`
 BUILD_ROOT="${GIT_ROOT}/packages/rpmbuild/BUILDROOT"
 
+mkdir -p ${GIT_ROOT}/packages/rpmbuild/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
+
 # Final package name
 package_name="${pkg_name}-${version}-0.00.${architecture}"
 

--- a/packages/rpmbuild/SPECS/foglamp.spec
+++ b/packages/rpmbuild/SPECS/foglamp.spec
@@ -13,7 +13,7 @@ URL:           http://www.dianomic.com
 %define install_path	/usr/local
 
 Prefix:        /usr/local
-Requires:      centos-release-scl , rh-python36, yum-utils, gcc, autoconf, curl, libtool, boost-devel, glib2-devel, rsyslog, openssl-devel, wget, zlib-devel, git, cmake, libuuid-devel, dbus-devel, postgresql-devel, avahi, sudo
+Requires:      rh-python36, yum-utils, gcc, autoconf, curl, libtool, boost-devel, glib2-devel, rsyslog, openssl-devel, wget, zlib-devel, git, cmake, libuuid-devel, dbus-devel, postgresql-devel, avahi, sudo
 AutoReqProv:   no
 
 %description

--- a/packages/rpmbuild/SPECS/foglamp.spec
+++ b/packages/rpmbuild/SPECS/foglamp.spec
@@ -2,7 +2,7 @@
 
 Name:          foglamp
 Vendor:        Dianomic Systems, Inc. <info@dianomic.com>
-Version:       1.5.02
+Version: 1.0.0
 Release:       0.0.00
 BuildArch:     x86_64
 Summary:       FogLAMP, the open source platform for the Internet of Things
@@ -284,7 +284,7 @@ link_update_task() {
 }
 
 copy_foglamp_sudoer_file() {
-    cp /usr/local/foglamp/bin/foglamp.sudoers /etc/sudoers.d/foglamp
+    cp /usr/local/foglamp/bin/foglamp.sudoers_rh /etc/sudoers.d/foglamp
 }
 
 copy_service_file() {

--- a/packages/rpmbuild/SPECS/foglamp.spec
+++ b/packages/rpmbuild/SPECS/foglamp.spec
@@ -13,7 +13,7 @@ URL:           http://www.dianomic.com
 %define install_path	/usr/local
 
 Prefix:        /usr/local
-Requires:      centos-release-scl, boost-devel, glib2-devel, rsyslog, openssl-devel, wget, zlib-devel, git, cmake, libuuid-devel, dbus-devel, sqlite, postgresql-devel, rh-python36, avahi, avahi-tools
+Requires:      boost-devel, glib2-devel, rsyslog, openssl-devel, wget, zlib-devel, git, cmake, libuuid-devel, dbus-devel, postgresql-devel, rh-python36, avahi
 AutoReqProv:   no
 
 
@@ -52,9 +52,8 @@ set -e
 PKG_NAME="foglamp"
 
 is_foglamp_installed () {
-    set +e
-    rm -f /var/run/yum.pid
-    rc=`yum list installed ${PKG_NAME} 2> /dev/null | grep -c foglamp`
+	set +e
+    rc=`rpm -qa  2> /dev/null  | grep -c ${PKG_NAME}`
     echo $rc
     set -e
 }
@@ -107,7 +106,7 @@ then
     fi
 
     # Persist current version in case of upgrade/downgrade
-    installed_version=`yum list installed ${PKG_NAME} | grep ${PKG_NAME} | awk '{print $2}'`
+    installed_version=`rpm -qi ${PKG_NAME} | grep Version |awk '{print $3}`
     if [ "${installed_version}" ]
     then
         # Persist current FogLAMP version: it will be removed by postinstall script

--- a/packages/rpmbuild/SPECS/foglamp.spec
+++ b/packages/rpmbuild/SPECS/foglamp.spec
@@ -106,7 +106,7 @@ then
     fi
 
     # Persist current version in case of upgrade/downgrade
-    installed_version=`rpm -qi ${PKG_NAME} | grep Version |awk '{print $3}`
+    installed_version=`rpm -qi ${PKG_NAME} | grep Version |awk '{print $3}'`
     if [ "${installed_version}" ]
     then
         # Persist current FogLAMP version: it will be removed by postinstall script

--- a/packages/rpmbuild/SPECS/foglamp.spec
+++ b/packages/rpmbuild/SPECS/foglamp.spec
@@ -13,14 +13,11 @@ URL:           http://www.dianomic.com
 %define install_path	/usr/local
 
 Prefix:        /usr/local
-Requires:      rh-python36, yum-utils, gcc, autoconf, curl, libtool, boost-devel, glib2-devel, rsyslog, openssl-devel, wget, zlib-devel, git, cmake, libuuid-devel, dbus-devel, postgresql-devel, avahi, sudo
+Requires:      centos-release-scl , rh-python36, yum-utils, gcc, autoconf, curl, libtool, boost-devel, glib2-devel, rsyslog, openssl-devel, wget, zlib-devel, git, cmake, libuuid-devel, dbus-devel, postgresql-devel, avahi, sudo
 AutoReqProv:   no
-
-
 
 %description
 FogLAMP, the open source platform for the Internet of Things
-
 
 %pre
 #!/usr/bin/env bash

--- a/packages/rpmbuild/SPECS/foglamp.spec
+++ b/packages/rpmbuild/SPECS/foglamp.spec
@@ -13,13 +13,14 @@ URL:           http://www.dianomic.com
 %define install_path	/usr/local
 
 Prefix:        /usr/local
-Requires:      yum-utils, gcc, autoconf, curl, libtool, boost-devel, glib2-devel, rsyslog, openssl-devel, wget, zlib-devel, git, cmake, libuuid-devel, dbus-devel, postgresql-devel, rh-python36, avahi, sudo
+Requires:      rh-python36, yum-utils, gcc, autoconf, curl, libtool, boost-devel, glib2-devel, rsyslog, openssl-devel, wget, zlib-devel, git, cmake, libuuid-devel, dbus-devel, postgresql-devel, avahi, sudo
 AutoReqProv:   no
 
 
 
 %description
 FogLAMP, the open source platform for the Internet of Things
+
 
 %pre
 #!/usr/bin/env bash

--- a/packages/rpmbuild/SPECS/foglamp.spec
+++ b/packages/rpmbuild/SPECS/foglamp.spec
@@ -1,0 +1,441 @@
+%define __spec_install_pre /bin/true
+
+Name:          foglamp
+Vendor:        Dianomic Systems, Inc. <info@dianomic.com>
+Version:       1.5.02
+Release:       0.0.00
+BuildArch:     x86_64
+Summary:       FogLAMP, the open source platform for the Internet of Things
+License:       Apache License
+Group: 	       IOT
+URL:           http://www.dianomic.com
+
+%define install_path	/usr/local
+
+Prefix:        /usr/local
+Requires:      centos-release-scl, boost-devel, glib2-devel, rsyslog, openssl-devel, wget, zlib-devel, git, cmake, libuuid-devel, dbus-devel, sqlite, postgresql-devel, rh-python36
+AutoReqProv:   no
+
+
+%description
+FogLAMP, the open source platform for the Internet of Things
+
+%pre
+#!/usr/bin/env bash
+
+##--------------------------------------------------------------------
+## Copyright (c) 2019 OSIsoft, LLC
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##--------------------------------------------------------------------
+
+##--------------------------------------------------------------------
+##
+## This script is used to execute pre installation tasks.
+##
+## Author: Ivan Zoratti, Ashwin Gopalakrishnan, Massimiliano Pinto, Stefano Simonelli
+##
+##--------------------------------------------------------------------
+
+# FIXME_I
+#set -e
+
+PKG_NAME="foglamp"
+
+is_foglamp_installed () {
+    set +e
+    # FIXME_I
+    sudo rm -f /var/run/yum.pid
+    rc=`yum list installed ${PKG_NAME} 2> /dev/null | grep -c foglamp`
+    echo $rc
+    set -e
+}
+
+get_foglamp_script () {
+    foglamp_script=$(rpm -ql ${PKG_NAME} | grep 'foglamp/bin/foglamp$')
+    echo $foglamp_script
+}
+
+is_foglamp_running () {
+    set +e
+    foglamp_script=$(get_foglamp_script)
+    foglamp_status_output=$($foglamp_script status 2>&1 | grep 'FogLAMP Uptime')
+    rc=$((!$?))
+    echo $rc
+    set -e
+}
+
+get_current_version_file () {
+    current_version_file=$(rpm -ql ${PKG_NAME} | grep VERSION)
+    echo $current_version_file
+}
+
+get_schema_version () {
+    version_file=$1
+    schema_version=$(grep foglamp_schema $version_file | awk -F = '{print $2}')
+    echo $schema_version
+}
+
+exists_schema_change_path () {
+    echo 1
+}
+
+# main
+
+# check if foglamp is installed
+IS_FOGLAMP_INSTALLED=$(is_foglamp_installed)
+
+# if foglamp is installed...
+if [ "$IS_FOGLAMP_INSTALLED" -eq "1" ]
+then
+    echo "FogLAMP is already installed: this is an upgrade/downgrade."
+
+    # exit if foglamp is running
+    IS_FOGLAMP_RUNNING=$(is_foglamp_running)
+    if [ "$IS_FOGLAMP_RUNNING" -eq "1" ]
+    then
+        echo "*** ERROR. FogLAMP is currently running. Stop FogLAMP and try again. ***"
+        exit 1
+    fi
+
+    # Persist current version in case of upgrade/downgrade
+    installed_version=`yum list installed ${PKG_NAME} | grep ${PKG_NAME} | awk '{print $2}'`
+    if [ "${installed_version}" ]
+    then
+        # Persist current FogLAMP version: it will be removed by postinstall script
+        this_dir=`pwd`
+        cd /usr/local/foglamp/
+        echo "${installed_version}" > .current_installed_version
+        cd ${this_dir}
+    fi
+
+    # check schema version file, exit if schema change path does not exist
+    CURRENT_VERSION_FILE=$(get_current_version_file)
+    CURRENT_SCHEMA_VERSION=$(get_schema_version $CURRENT_VERSION_FILE)
+    echo "FogLAMP currently has schema version $CURRENT_SCHEMA_VERSION"
+    EXISTS_SCHEMA_CHANGE_PATH=$(exists_schema_change_path)
+    if [ "$EXISTS_SCHEMA_CHANGE_PATH" -eq "0" ]
+    then
+        echo "*** ERROR. There is no schema change path from the installed version to the new version. ***"
+        exit 1
+    fi
+
+fi
+
+
+
+%preun
+#!/usr/bin/env bash
+
+##--------------------------------------------------------------------
+## Copyright (c) 2019 OSIsoft, LLC
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##--------------------------------------------------------------------
+
+##--------------------------------------------------------------------
+##
+## This script is used to execute before the removal of files associated with the package.
+##
+## Author: Ivan Zoratti, Ashwin Gopalakrishnan, Stefano Simonelli
+##
+##----------------------------------------------------------------------------------------
+
+# FIXME_I
+#set -e
+
+PKG_NAME="foglamp"
+
+get_foglamp_script () {
+    foglamp_script=$(rpm -ql ${PKG_NAME} | grep 'foglamp/bin/foglamp$')
+    echo $foglamp_script
+}
+
+stop_foglamp_service () {
+    systemctl stop foglamp
+}
+
+is_foglamp_running () {
+    set +e
+    foglamp_script=$(get_foglamp_script)
+    foglamp_status_output=$($foglamp_script status 2>&1 | grep 'FogLAMP Uptime')
+    rc=$((!$?))
+    echo $rc
+    set -e
+}
+
+kill_foglamp () {
+    set +e
+    foglamp_script=$(get_foglamp_script)
+    foglamp_status_output=$($foglamp_script kill 2>&1)
+    set -e
+}
+
+disable_foglamp_service () {
+	# FIXME_I
+	set +e
+    sudo systemctl disable foglamp
+    set -e
+}
+
+remove_foglamp_service_file () {
+    rm -rf /etc/init.d/foglamp
+}
+
+reset_systemctl () {
+    sudo systemctl daemon-reload
+    sudo systemctl reset-failed
+}
+
+remove_pycache_files () {
+    set +e
+    # FIXME_I
+    find /usr/local/foglamp -name "*.pyc" -exec rm -rf {} \;
+    find /usr/local/foglamp -name "__pycache__" -exec rm -rf {} \;
+    set -e
+}
+
+remove_data_files () {
+	rm -rf /usr/local/foglamp/data
+
+}
+
+# main
+
+IS_FOGLAMP_RUNNING=$(is_foglamp_running)
+
+if [ "$IS_FOGLAMP_RUNNING" -eq "1" ]
+then
+    echo "FogLAMP is currently running."
+    echo "Stop FogLAMP service."
+    stop_foglamp_service
+    echo "Kill FogLAMP."
+    kill_foglamp
+fi
+
+#echo "Remove data directory."
+#remove_data_files
+echo "Remove python cache files."
+remove_pycache_files
+echo "Disable FogLAMP service."
+disable_foglamp_service
+echo "Remove FogLAMP service script"
+remove_foglamp_service_file
+echo "Reset systemctl"
+reset_systemctl
+
+
+%post
+#!/usr/bin/env bash
+
+##--------------------------------------------------------------------
+## Copyright (c) 2019 OSIsoft, LLC
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##--------------------------------------------------------------------
+
+##--------------------------------------------------------------------
+##
+## This script is used to execute post installation tasks.
+##
+## Author: Ivan Zoratti, Massimiliano Pinto, Stefano Simonelli
+##
+##--------------------------------------------------------------------
+
+# FIXME_I
+#set -e
+
+
+# certificate generation defaults
+SSL_NAME="foglamp"
+SSL_DAYS="365"
+AUTH_NAME="ca"
+
+link_update_task() {
+    echo "Changing setuid of update_task.rpm"
+    chmod ugo+s /usr/local/foglamp/bin/update_task.rpm
+    echo "Removing task/update"
+    [ -e /usr/local/foglamp/scripts/tasks/update ] && rm  /usr/local/foglamp/scripts/tasks/update
+    echo "Create link file"
+    ln -s /usr/local/foglamp/bin/update_task.rpm /usr/local/foglamp/scripts/tasks/update
+}
+
+copy_foglamp_sudoer_file() {
+    cp /usr/local/foglamp/bin/foglamp.sudoers /etc/sudoers.d/foglamp
+}
+
+copy_service_file() {
+    cp /usr/local/foglamp/extras/scripts/foglamp.service /etc/init.d/foglamp
+}
+
+enable_foglamp_service() {
+	# FIXME_I
+    #systemctl enable foglamp
+	/sbin/chkconfig foglamp on
+
+}
+
+start_foglamp_service() {
+	# FIXME_I
+    #systemctl start foglamp
+    echo ""
+}
+
+set_files_ownership () {
+    chown root:root /etc/init.d/foglamp
+    chown -R root:root /usr/local/foglamp
+    chown -R ${SUDO_USER}:${SUDO_USER} /usr/local/foglamp/data
+
+}
+
+generate_certs () {
+    if [ ! -f /usr/local/foglamp/data/etc/certs/foglamp.cert ]; then
+        echo "Certificate files do not exist. Generating new certificate files."
+        cd /usr/local/foglamp
+        ./scripts/certificates ${SSL_NAME} ${SSL_DAYS}
+    else
+        echo "Certificate files already exist. Skipping generating new certificate files."
+    fi
+}
+
+generate_auth_certs () {
+    if [ ! -f /usr/local/foglamp/data/etc/certs/ca.cert ]; then
+        echo "CA Certificate file does not exist. Generating new CA certificate file."
+        cd /usr/local/foglamp
+        ./scripts/auth_certificates ca ${AUTH_NAME} ${SSL_DAYS}
+    else
+        echo "CA Certificate file already exists. Skipping generating new CA certificate file."
+    fi
+    if [ ! -f /usr/local/foglamp/data/etc/certs/admin.cert ]; then
+        echo "Admin Certificate file does not exist. Generating new admin certificate file."
+        cd /usr/local/foglamp
+        ./scripts/auth_certificates user admin ${SSL_DAYS}
+    else
+        echo "Admin Certificate file already exists. Skipping generating new admin certificate file."
+    fi
+    if [ ! -f /usr/local/foglamp/data/etc/certs/user.cert ]; then
+        echo "User Certificate file does not exist. Generating new user certificate file."
+        cd /usr/local/foglamp
+        ./scripts/auth_certificates user user ${SSL_DAYS}
+    else
+        echo "User Certificate file already exists. Skipping generating new user certificate file."
+    fi
+}
+
+copy_new_data () {
+    if [ ! -d /usr/local/foglamp/data ]; then
+        echo "Data directory does not exist. Using new data directory"
+        mv /usr/local/foglamp/data.new /usr/local/foglamp/data
+    else
+        echo "Data directory already exists. Updating data/extras/fogbench/fogbench_sensor_coap.template.json only."
+        if [ -f /usr/local/foglamp/data.new/extras/fogbench/fogbench_sensor_coap.template.json  ]; then
+
+            cp /usr/local/foglamp/data.new/extras/fogbench/fogbench_sensor_coap.template.json /usr/local/foglamp/data/extras/fogbench/fogbench_sensor_coap.template.json
+		fi
+        rm -rf /usr/local/foglamp/data.new
+    fi
+}
+
+install_pip3_packages () {
+
+	echo "# "                                   >> /home/${SUDO_USER}/.bashrc
+	echo "# added by FogLamp"                   >> /home/${SUDO_USER}/.bashrc
+	echo "source scl_source enable rh-python36" >> /home/${SUDO_USER}/.bashrc
+
+	source scl_source enable rh-python36
+
+	pip install -Ir /usr/local/foglamp/python/requirements.txt
+
+	sudo bash -c 'source scl_source enable rh-python36;pip install dbus-python'
+}
+
+# Call FogLAMP package update script
+# Any message will be written by called update script
+call_package_update_script () {
+    # File created by presinstall hook
+    installed_version_file="/usr/local/foglamp/.current_installed_version"
+    if [ -s "${installed_version_file}" ]; then
+        current_installed_version=`cat ${installed_version_file}`
+        update_script="/usr/local/foglamp/scripts/package/rpm/package_update.sh"
+        # Check update script exists
+        if [ -x "${update_script}" ] && [ -s "${update_script}" ] && [ -O "${update_script}" ]; then
+            # Call RPM update script passing the previous version
+            ${update_script} ${current_installed_version}
+        fi
+        # Update done: remove temp file
+        rm ${installed_version_file}
+    fi
+}
+
+
+
+# main
+
+echo "Install python dependencies"
+install_pip3_packages
+
+echo "Resolving data directory"
+copy_new_data
+
+echo "Installing service script"
+copy_service_file
+
+echo "Generating certificate files"
+generate_certs
+
+echo "Generating auth certificate files"
+generate_auth_certs
+
+echo "Setting ownership of FogLAMP files"
+set_files_ownership
+
+# Call FogLAMP package update script
+# TODO: DISABLED - to be implemented
+#call_package_update_script
+
+#TODO: DISABLED - to be implemented
+#echo "Linking update task"
+#link_update_task
+
+echo "Copying sodoers file"
+copy_foglamp_sudoer_file
+
+echo "Enabling FogLAMP service"
+enable_foglamp_service
+
+echo "Starting FogLAMP service"
+start_foglamp_service
+
+
+%files
+%{install_path}/*

--- a/packages/rpmbuild/SPECS/foglamp.spec
+++ b/packages/rpmbuild/SPECS/foglamp.spec
@@ -13,7 +13,7 @@ URL:           http://www.dianomic.com
 %define install_path	/usr/local
 
 Prefix:        /usr/local
-Requires:      gcc, autoconf, curl, libtool, boost-devel, glib2-devel, rsyslog, openssl-devel, wget, zlib-devel, git, cmake, libuuid-devel, dbus-devel, postgresql-devel, rh-python36, avahi
+Requires:      yum-utils, gcc, autoconf, curl, libtool, boost-devel, glib2-devel, rsyslog, openssl-devel, wget, zlib-devel, git, cmake, libuuid-devel, dbus-devel, postgresql-devel, rh-python36, avahi, sudo
 AutoReqProv:   no
 
 

--- a/packages/rpmbuild/SPECS/foglamp.spec
+++ b/packages/rpmbuild/SPECS/foglamp.spec
@@ -53,7 +53,7 @@ PKG_NAME="foglamp"
 
 is_foglamp_installed () {
     set +e
-    sudo rm -f /var/run/yum.pid
+    rm -f /var/run/yum.pid
     rc=`yum list installed ${PKG_NAME} 2> /dev/null | grep -c foglamp`
     echo $rc
     set -e
@@ -199,8 +199,8 @@ remove_foglamp_service_file () {
 }
 
 reset_systemctl () {
-    sudo systemctl daemon-reload
-    sudo systemctl reset-failed
+    systemctl daemon-reload
+    systemctl reset-failed
 }
 
 remove_pycache_files () {

--- a/packages/rpmbuild/SPECS/foglamp.spec
+++ b/packages/rpmbuild/SPECS/foglamp.spec
@@ -1,10 +1,10 @@
 %define __spec_install_pre /bin/true
 
-Name:          foglamp
+Name:          __NAME__
 Vendor:        Dianomic Systems, Inc. <info@dianomic.com>
-Version: 1.0.0
-Release:       0.0.00
-BuildArch:     x86_64
+Version:       __VERSION__
+Release:       0.00
+BuildArch:     __ARCH__
 Summary:       FogLAMP, the open source platform for the Internet of Things
 License:       Apache License
 Group: 	       IOT
@@ -13,7 +13,7 @@ URL:           http://www.dianomic.com
 %define install_path	/usr/local
 
 Prefix:        /usr/local
-Requires:      centos-release-scl, boost-devel, glib2-devel, rsyslog, openssl-devel, wget, zlib-devel, git, cmake, libuuid-devel, dbus-devel, sqlite, postgresql-devel, rh-python36
+Requires:      centos-release-scl, boost-devel, glib2-devel, rsyslog, openssl-devel, wget, zlib-devel, git, cmake, libuuid-devel, dbus-devel, sqlite, postgresql-devel, rh-python36, avahi, avahi-tools
 AutoReqProv:   no
 
 

--- a/packages/rpmbuild/SPECS/foglamp.spec
+++ b/packages/rpmbuild/SPECS/foglamp.spec
@@ -47,14 +47,12 @@ FogLAMP, the open source platform for the Internet of Things
 ##
 ##--------------------------------------------------------------------
 
-# FIXME_I
-#set -e
+set -e
 
 PKG_NAME="foglamp"
 
 is_foglamp_installed () {
     set +e
-    # FIXME_I
     sudo rm -f /var/run/yum.pid
     rc=`yum list installed ${PKG_NAME} 2> /dev/null | grep -c foglamp`
     echo $rc
@@ -161,8 +159,7 @@ fi
 ##
 ##----------------------------------------------------------------------------------------
 
-# FIXME_I
-#set -e
+set -e
 
 PKG_NAME="foglamp"
 
@@ -192,9 +189,8 @@ kill_foglamp () {
 }
 
 disable_foglamp_service () {
-	# FIXME_I
 	set +e
-    sudo systemctl disable foglamp
+	/sbin/chkconfig foglamp off
     set -e
 }
 
@@ -209,7 +205,6 @@ reset_systemctl () {
 
 remove_pycache_files () {
     set +e
-    # FIXME_I
     find /usr/local/foglamp -name "*.pyc" -exec rm -rf {} \;
     find /usr/local/foglamp -name "__pycache__" -exec rm -rf {} \;
     set -e
@@ -272,9 +267,7 @@ reset_systemctl
 ##
 ##--------------------------------------------------------------------
 
-# FIXME_I
-#set -e
-
+set -e
 
 # certificate generation defaults
 SSL_NAME="foglamp"
@@ -299,16 +292,12 @@ copy_service_file() {
 }
 
 enable_foglamp_service() {
-	# FIXME_I
-    #systemctl enable foglamp
-	/sbin/chkconfig foglamp on
 
+	/sbin/chkconfig foglamp on
 }
 
 start_foglamp_service() {
-	# FIXME_I
-    #systemctl start foglamp
-    echo ""
+    systemctl start foglamp
 }
 
 set_files_ownership () {
@@ -367,7 +356,7 @@ copy_new_data () {
 }
 
 install_pip3_packages () {
-
+	set +e
 	echo "# "                                   >> /home/${SUDO_USER}/.bashrc
 	echo "# added by FogLamp"                   >> /home/${SUDO_USER}/.bashrc
 	echo "source scl_source enable rh-python36" >> /home/${SUDO_USER}/.bashrc
@@ -377,6 +366,7 @@ install_pip3_packages () {
 	pip install -Ir /usr/local/foglamp/python/requirements.txt
 
 	sudo bash -c 'source scl_source enable rh-python36;pip install dbus-python'
+	set -e
 }
 
 # Call FogLAMP package update script

--- a/packages/rpmbuild/SPECS/foglamp.spec
+++ b/packages/rpmbuild/SPECS/foglamp.spec
@@ -358,10 +358,16 @@ copy_new_data () {
 
 install_pip3_packages () {
 	set +e
-	echo "# "                                   >> /home/${SUDO_USER}/.bashrc
-	echo "# added by FogLamp"                   >> /home/${SUDO_USER}/.bashrc
-	echo "source scl_source enable rh-python36" >> /home/${SUDO_USER}/.bashrc
 
+	foglam_test="added by FogLamp"
+	check_already_added=`cat /home/${SUDO_USER}/.bashrc | grep -c "${foglam_test}"`
+
+	if [ "$check_already_added" -eq "0" ]
+	then
+		echo "# "                                   >> /home/${SUDO_USER}/.bashrc
+		echo "# ${foglam_test}"                     >> /home/${SUDO_USER}/.bashrc
+		echo "source scl_source enable rh-python36" >> /home/${SUDO_USER}/.bashrc
+	fi
 	source scl_source enable rh-python36
 
 	pip install -Ir /usr/local/foglamp/python/requirements.txt

--- a/packages/rpmbuild/SPECS/foglamp.spec
+++ b/packages/rpmbuild/SPECS/foglamp.spec
@@ -13,7 +13,7 @@ URL:           http://www.dianomic.com
 %define install_path	/usr/local
 
 Prefix:        /usr/local
-Requires:      boost-devel, glib2-devel, rsyslog, openssl-devel, wget, zlib-devel, git, cmake, libuuid-devel, dbus-devel, postgresql-devel, rh-python36, avahi
+Requires:      @development, boost-devel, glib2-devel, rsyslog, openssl-devel, wget, zlib-devel, git, cmake, libuuid-devel, dbus-devel, postgresql-devel, rh-python36, avahi
 AutoReqProv:   no
 
 

--- a/packages/rpmbuild/SPECS/foglamp.spec
+++ b/packages/rpmbuild/SPECS/foglamp.spec
@@ -13,7 +13,7 @@ URL:           http://www.dianomic.com
 %define install_path	/usr/local
 
 Prefix:        /usr/local
-Requires:      rh-python36, yum-utils, gcc, autoconf, curl, libtool, boost-devel, glib2-devel, rsyslog, openssl-devel, wget, zlib-devel, git, cmake, libuuid-devel, dbus-devel, postgresql-devel, avahi, sudo
+Requires:      dbus-devel, glib2-devel, boost, openssl, rh-python36, yum-utils, gcc, autoconf, curl, libtool,  rsyslog,  wget, zlib, libuuid, postgresql, avahi, sudo
 AutoReqProv:   no
 
 %description

--- a/packages/rpmbuild/SPECS/foglamp.spec
+++ b/packages/rpmbuild/SPECS/foglamp.spec
@@ -13,8 +13,9 @@ URL:           http://www.dianomic.com
 %define install_path	/usr/local
 
 Prefix:        /usr/local
-Requires:      @development, boost-devel, glib2-devel, rsyslog, openssl-devel, wget, zlib-devel, git, cmake, libuuid-devel, dbus-devel, postgresql-devel, rh-python36, avahi
+Requires:      gcc, autoconf, curl, libtool, boost-devel, glib2-devel, rsyslog, openssl-devel, wget, zlib-devel, git, cmake, libuuid-devel, dbus-devel, postgresql-devel, rh-python36, avahi
 AutoReqProv:   no
+
 
 
 %description


### PR DESCRIPTION
**READY**

**dependencies optimization**
these are needed  to avoid an error

- dbus-devel
- glib2-devel 

Error:
```
[foglamp@rpmtest ~]$ sudo cat  /usr/local/foglamp/data/core.err
Traceback (most recent call last):
  File "/opt/rh/rh-python36/root/usr/lib64/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/opt/rh/rh-python36/root/usr/lib64/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/usr/local/foglamp/python/foglamp/services/core/__main__.py", line 11, in <module>
    from foglamp.services.core.server import Server
  File "/usr/local/foglamp/python/foglamp/services/core/server.py", line 43, in <module>
    from foglamp.services.common.service_announcer import ServiceAnnouncer
  File "/usr/local/foglamp/python/foglamp/services/common/service_announcer.py", line 9, in <module>
    import foglamp.services.common.avahi as avahi
  File "/usr/local/foglamp/python/foglamp/services/common/avahi.py", line 20, in <module>
    import dbus
ModuleNotFoundError: No module named 'dbus'
```