### PR TITLE
FOGL-2821_patch requirements.sh run without sh

### DIFF
--- a/plugins/make_plugin_rpm
+++ b/plugins/make_plugin_rpm
@@ -219,7 +219,7 @@ EOF
 	else
 		(cd ${GIT_ROOT}; 
 			if [ -f requirements.sh ]; then
-				sudo sh requirements.sh
+				sudo ./requirements.sh
 			fi
 			mkdir -p build; cd build; cmake ..; make)
 		mkdir -p "plugins/${plugin_type_install}/${plugin_install_dirname}"


### PR DESCRIPTION
As it breaks on `ubuntu`
sudo `sh requirements.sh   Vs   ./requirements.sh`

Reference https://github.com/foglamp/foglamp-notify-blynk/pull/8/files

See the below error

```
foglamp@nerd-034 ~/Development/foglamp-notify-blynk (FOGL-2817) $ sh requirements.sh 
Platform is Ubuntu, Version: 16.04
requirements.sh: 30: requirements.sh: Syntax error: word unexpected (expecting ")")
```

Otherwise we need to change the logic for os_check below for every plugin we fixed for
https://github.com/foglamp/foglamp-notify-blynk/pull/8/files#diff-a17370e1077809f0c02d540f79f2a8eeR30