### PR TITLE
FOGL-2839 requirements should not be run as root

### DIFF
--- a/plugins/make_plugin_rpm
+++ b/plugins/make_plugin_rpm
@@ -219,7 +219,7 @@ EOF
 	else
 		(cd ${GIT_ROOT}; 
 			if [ -f requirements.sh ]; then
-				sudo ./requirements.sh
+				./requirements.sh
 			fi
 			mkdir -p build; cd build; cmake ..; make)
 		mkdir -p "plugins/${plugin_type_install}/${plugin_install_dirname}"


### PR DESCRIPTION
Note some requirements.sh scripts may need to be modified to include sudo on individual commands