### PR TITLE
FOGL-2772 Centralised plugin packaging for DEBIAN files

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -214,3 +214,9 @@ Cleaning the Package Folder
 
 Use the ``clean`` option to remove all the old packages and the files used to make the package.
 Use the ``cleanall`` option to remove all the packages and the files used to make the package.
+
+
+Packaging for Plugins
+======================
+
+Please refer to documentation `here <plugins/README.rst>`_

--- a/plugins/README.rst
+++ b/plugins/README.rst
@@ -1,0 +1,126 @@
+*****************************
+Packaging for FogLAMP Plugins
+*****************************
+
+This directory contains the deb and rpm scripts used to create a FogLAMP plugins package.
+
+Internal Structure
+==================
+
+The directory contains the following set of files:
+
+- Files named with **make_** prefix, such as ``make_deb``, ``make_rpm``, are the shell scripts used to build the package.
+- The **packages** folder contains the list package types to build. It contains *DEBIAN* and *RPM*
+
+  - Inside the *packages/DEBIAN* folder, which contains all the Debian-based files, i.e. control, postinst, needed for the creation of the package.
+
+    - In the *archive/DEBIAN/architecture_name* folder which contains the build package.
+
+  - Inside the *packages/RPM/SPECS* folder, which contains RPM spec-based file, i.e. plugin.spec needed for the creation of the package.
+
+    - In the *archive/architecture_name* folder folder which contains the build package.
+
+
+The make_deb Script
+===================
+
+.. code-block:: console
+
+  $ ./make_deb -h
+  make_deb [-h] [-a] [-b <branch>] repository ...
+  This script is used to create the Debian package for a FogLAMP plugin
+
+  Arguments:
+  -h	- Display this help text
+  -a	- Remove all the versions
+  -b	- Branch to base package on
+  $
+
+
+Building a Debian Package
+=========================
+
+First, make sure that FogLAMP_ROOT is set.
+Finally, run the ``make_deb`` command:
+
+.. code-block:: console
+
+  $ ./make_deb -b develop foglamp-south-sinusoid
+  Cloning into 'foglamp-south-sinusoid'...
+
+  Checking connectivity... done.
+  Version is 1.6.0
+  The package root directory is                         : /tmp/foglamp-south-sinusoid
+  The FogLAMP south sinusoid  version is                : 1.6.0
+  The package will be built in                          : /tmp/foglamp-south-sinusoid/packages/build
+  The package name is                                   : foglamp-south-sinusoid-1.6.0
+
+  Populating the package and updating version file...Done.
+  Building the new package...
+  dpkg-deb: building package 'foglamp-south-sinusoid' in 'foglamp-south-sinusoid-1.6.0.deb'.
+  Building Complete.
+  $
+  
+The result will be:
+  
+.. code-block:: console
+
+  $ ls -l archive/DEBIAN/x86_64/
+  total 8
+  drwxrwxr-x 4 foglamp foglamp  4096 foglamp-south-sinusoid-1.6.0
+  -rw-r--r-- 1 foglamp foglamp  3338 foglamp-south-sinusoid-1.6.0.deb
+  $
+
+The make_rpm Script
+===================
+.. code-block:: console
+
+  $ ./make_rpm --help
+  make_rpm [-a] [-c] [-h] [-b <branch>] repository ...
+  This script is used to create the RPM package for a FogLAMP plugin
+
+  Arguments:
+    -h	- Display this help text
+    -c	- Remove all the old versions saved in format .XXXX
+    -a	- Remove all the versions, including the last one
+    -b	- Branch to base package on
+  $
+
+Building a RPM Package
+======================
+
+First, make sure that FogLAMP_ROOT is set.
+Finally, run the ``make_rpm`` command:
+
+.. code-block:: console
+
+  $ ./make_rpm -b develop foglamp-south-sinusoid
+  Cloning into 'foglamp-south-sinusoid'...
+  Checking connectivity... done.
+  Version is 1.6.0
+  The package root directory is                        : /tmp/foglamp-south-sinusoid
+  The FogLAMP south sinusoid version is                : 1.6.0
+  The package will be built in                         : /tmp/foglamp-south-sinusoid/packages/build
+  The package name is                                  : foglamp-south-sinusoid-1.6.0
+
+  Populating the package and updating version file...Done.
+  Building the new package...
+  Processing files: foglamp-south-sinusoid-1.6.0-1.x86_64
+  Checking for unpackaged file(s): /usr/lib/rpm/check-files /tmp/foglamp-south-sinusoid/packages/build/foglamp-south-sinusoid-1.6.0/BUILDROOT/foglamp-south-sinusoid-1.6.0-1.x86_64
+  Wrote: /tmp/foglamp-south-sinusoid/packages/build/foglamp-south-sinusoid-1.6.0/RPMS/x86_64/foglamp-south-sinusoid-1.6.0-1.x86_64.rpm
+  Building Complete.
+  $
+
+The result will be:
+
+.. code-block:: console
+
+  $ ls -l archive/x86_64
+  total 12
+  -rw-rw-r-- 1 foglamp foglamp 11805 foglamp-south-sinusoid-1.6.0-1.x86_64.rpm
+  $
+
+Cleaning the Package Folder
+===========================
+
+Use the ``-a`` option to remove all the packages and the files used to make the package.

--- a/plugins/make_deb
+++ b/plugins/make_deb
@@ -1,0 +1,235 @@
+#!/bin/bash
+
+##--------------------------------------------------------------------
+## Copyright (c) 2019 Dianomic Systems Inc.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##--------------------------------------------------------------------
+##
+## Author: Ashish Jabble
+##
+
+set -e
+
+# Default branch to package
+BRANCH_NAME=master
+USAGE="$(basename "$0") [-h] [-a] [-b <branch>] repository ...
+This script is used to create the Debian package for a FogLAMP plugin
+
+Arguments:
+  -h	- Display this help text
+  -a	- Remove all the versions
+  -b	- Branch to base package on"
+
+while getopts ":hab:" opt; do
+	case "$opt" in
+		a)
+			if [ -d "./archive" ]; then
+				echo -n "Cleaning the package archive folder..."
+				rm -rf ./archive/*
+				echo "Done."
+			else
+				echo "No archive folder, skipping cleanall"
+			fi
+			exit 0
+			;;
+		h)
+			echo "${USAGE}"
+			exit 0
+			;;
+		b)
+			BRANCH_NAME=$OPTARG
+			;;
+		\?)
+			echo "Invalid option -$OPTARG"
+			exit 1
+			;;
+		:)
+			echo "-$OPTARG requires an argument"
+			exit 1
+	esac
+done
+shift $((OPTIND -1))
+
+REPO_NAME=$1
+
+if [ "${REPO_NAME}" = "" ]; then
+	echo You must specify plugin repository name to package
+	exit 1
+fi
+
+while [ "${REPO_NAME}" != "" ]
+do
+	package_manager=deb
+	arch=`arch`
+	archive=`pwd`/archive/DEBIAN
+	if [ ! -d "${archive}/${arch}" ]; then
+		mkdir -p "${archive}/${arch}"
+	fi
+
+	PKG_ROOT=`pwd`
+	cd /tmp
+	if [ -d "${REPO_NAME}" ]; then
+		echo WARNING: Repository ${REPO_NAME} already exists, using the existing copy
+		(cd ${REPO_NAME}; git pull; git checkout "${BRANCH_NAME}")
+	else
+		git clone -b ${BRANCH_NAME} --single-branch https://github.com/foglamp/${REPO_NAME}.git
+	fi
+
+	GIT_ROOT=/tmp/"${REPO_NAME}"
+	cd ${GIT_ROOT}
+
+	if [ ! -f "${GIT_ROOT}/Package" ]; then
+		echo Repository ${REPO_NAME} is missing package directive file
+		rm -rf "${GIT_ROOT}"
+		exit 1
+	fi
+
+	if [ ! -f "${GIT_ROOT}/Description" ]; then
+		echo Repository ${REPO_NAME} is missing package description file
+		rm -rf "${GIT_ROOT}"
+		exit 1
+	fi
+
+	. "${GIT_ROOT}"/Package
+	pkg_name="${REPO_NAME}"
+
+    if [ -f "${GIT_ROOT}/VERSION" ]; then
+		version=`cat "${GIT_ROOT}/VERSION"`
+        foglamp_version=`cat ${GIT_ROOT}/foglamp.version | tr -d ' ' | grep 'foglamp_version' | head -1 | sed -e 's/\(.*\)version\(.*\)/\2/g'`
+	elif [ -f "${GIT_ROOT}/VERSION.${plugin_type}.${plugin_name}" ]; then
+		  version=`cat "${GIT_ROOT}/VERSION.${plugin_type}.${plugin_name}" | tr -d ' ' | grep "foglamp_${plugin_type}_${plugin_name}_version" | head -1 | sed -e 's/\(.*\)=\(.*\)/\2/g'`
+		  foglamp_version=`cat ${GIT_ROOT}/VERSION.${plugin_type}.${plugin_name} | tr -d ' ' | grep 'foglamp_version' | head -1 | sed -e 's/\(.*\)version\(.*\)/\2/g'`
+	else
+		echo Unable to determine version of package to create
+		rm -rf "${GIT_ROOT}"
+		exit 1
+	fi
+	echo Version is $version
+    BUILD_ROOT="${GIT_ROOT}/packages/build"
+    if [ "${plugin_package_name}" ]; then
+        pkg_name=${plugin_package_name}
+    else
+        pkg_name="foglamp-${plugin_type}-${plugin_name}"
+    fi
+    # Final package name
+    package_name="${pkg_name}-${version}"
+
+    # Print the summary of findings
+    echo "The package root directory is                         : ${GIT_ROOT}"
+    echo "The FogLAMP ${plugin_type} ${plugin_name}  version is : ${version}"
+    echo "The package will be built in                          : ${BUILD_ROOT}"
+    echo "The package name is                                   : ${package_name}"
+    if [ -f "${GIT_ROOT}/service_notification.version" ]; then
+	     service_notification_version=`cat ${GIT_ROOT}/service_notification.version | tr -d ' ' | grep 'service_notification_version' | head -1 | sed -e 's/\(.*\)version\([>=|>|<|<=|=]*\)\(.*\)/\2 \3/g'`
+	     echo "The Service notification required version        : ${service_notification_version}"
+	fi
+    echo
+
+    # Create the package directory. If a directory with the same name exists,
+    # it is copied with a version number.
+
+    # First, create the BUILD_ROOT folder, if necessary
+    if [ ! -L "${BUILD_ROOT}" -a ! -d "${BUILD_ROOT}" ]; then
+        mkdir -p "${BUILD_ROOT}"
+    fi
+
+    cd "${BUILD_ROOT}"
+    existing_pkgs=`find . -maxdepth 1 -name "${package_name}.????" | wc -l`
+    existing_pkgs=$((existing_pkgs+1))
+    new_stored_pkg=$(printf "${package_name}.%04d" "${existing_pkgs}")
+    if [ -d "${package_name}" ]; then
+        echo "Saving the old working environment as ${new_stored_pkg}"
+        mv "${package_name}" "${new_stored_pkg}"
+    fi
+    mkdir "${package_name}"
+
+    # If plugin_type_install if not set use plugin_type value
+	if [ "${plugin_type}" = "notify" ]; then
+	    plugin_type_install="notificationDelivery"
+    elif [ "${plugin_type}" = "rule" ]; then
+	    plugin_type_install="notificationRule"
+	else
+	    plugin_type_install=${plugin_type}
+	fi
+
+	# Install directory path
+	if [ -d ${GIT_ROOT}/python ]; then
+	    installs=python/foglamp/plugins/${plugin_type_install}/${plugin_install_dirname}
+	else
+	    installs=plugins/${plugin_type_install}/${plugin_install_dirname}
+	fi
+
+    # Populate the package directory with Debian files
+    # First with files common to all plugins
+    echo -n "Populating the package and updating version file..."
+    cd "${package_name}"
+    mkdir DEBIAN
+    archname=$(dpkg --print-architecture)
+    deb_path=${BUILD_ROOT}/${package_name}/DEBIAN
+    cp -R ${PKG_ROOT}/packages/DEBIAN/* ${deb_path}
+    sed -i "s/__VERSION__/${version}/g" ${deb_path}/control
+	sed -i "s/__NAME__/${pkg_name}/g" ${deb_path}/control
+	sed -i "s/__ARCH__/${archname}/g" ${deb_path}/control
+	sed -i "s/__REQUIRES__/${requirements}/g" ${deb_path}/control
+	sed -i "s/foglamp,/foglamp (${foglamp_version}),/" ${deb_path}/control
+	sed -i "s/foglamp$/foglamp (${foglamp_version})/" ${deb_path}/control
+	sed -i "s|__INSTALL_DIR__|${installs}|g" ${deb_path}/postinst
+	sed -i "s/__PLUGIN_NAME__/${plugin_name}/g" ${deb_path}/postinst
+    desc=`cat "${GIT_ROOT}/Description"`
+    sed -i "s/__DESCRIPTION__/${desc}/g" ${deb_path}/control
+
+    # Creating packaging file structure
+    mkdir -p usr/local/foglamp
+    cd usr/local/foglamp
+    if [ -d ${GIT_ROOT}/python ]; then
+		find ${GIT_ROOT}/python | grep -E "(__pycache__|\.pyc|\.pyo$)" | xargs rm -rf
+		cp -R ${GIT_ROOT}/python .
+		cp -R ${GIT_ROOT}/VERSION.${plugin_type}.${plugin_name} .
+	else
+		(cd ${GIT_ROOT};
+			if [ -f requirements.sh ]; then
+				./requirements.sh
+			fi
+			mkdir -p build; cd build; cmake ..; make)
+		mkdir -p "plugins/${plugin_type_install}/${plugin_install_dirname}"
+		cp -R --preserve=links ${GIT_ROOT}/build/lib* "plugins/${plugin_type_install}/${plugin_install_dirname}"
+	fi
+	echo "Done."
+
+    # Build the package
+    cd "${BUILD_ROOT}"
+
+    # Save the old versions
+    existing_pkgs=`find . -maxdepth 1 -name "${package_name}.deb.????" | wc -l`
+    existing_pkgs=$((existing_pkgs+1))
+    new_stored_pkg=$(printf "${package_name}.deb.%04d" "${existing_pkgs}")
+
+    if [ -e "${package_name}.deb" ]; then
+        echo "Saving the old package as ${new_stored_pkg}"
+        mv "${package_name}.deb" "${new_stored_pkg}"
+    fi
+
+    echo "Building the new package..."
+    dpkg-deb --build ${package_name}
+    echo "Building Complete."
+
+    # Move final package to archive directory
+    cp  ${BUILD_ROOT}/${package_name}.deb ${archive}/${arch}/${fullname}
+	cp -R ${BUILD_ROOT}/${package_name} ${archive}/${arch}/${fullname}
+
+    rm -rf /tmp/${REPO_NAME}
+    exit 0
+done
+exit 0
+

--- a/plugins/make_deb
+++ b/plugins/make_deb
@@ -105,16 +105,16 @@ do
 	pkg_name="${REPO_NAME}"
 
     if [ -f "${GIT_ROOT}/VERSION" ]; then
-		version=`cat "${GIT_ROOT}/VERSION"`
+        version=`cat "${GIT_ROOT}/VERSION"`
         foglamp_version=`cat ${GIT_ROOT}/foglamp.version | tr -d ' ' | grep 'foglamp_version' | head -1 | sed -e 's/\(.*\)version\(.*\)/\2/g'`
-	elif [ -f "${GIT_ROOT}/VERSION.${plugin_type}.${plugin_name}" ]; then
-		  version=`cat "${GIT_ROOT}/VERSION.${plugin_type}.${plugin_name}" | tr -d ' ' | grep "foglamp_${plugin_type}_${plugin_name}_version" | head -1 | sed -e 's/\(.*\)=\(.*\)/\2/g'`
-		  foglamp_version=`cat ${GIT_ROOT}/VERSION.${plugin_type}.${plugin_name} | tr -d ' ' | grep 'foglamp_version' | head -1 | sed -e 's/\(.*\)version\(.*\)/\2/g'`
-	else
-		echo Unable to determine version of package to create
-		rm -rf "${GIT_ROOT}"
-		exit 1
-	fi
+    elif [ -f "${GIT_ROOT}/VERSION.${plugin_type}.${plugin_name}" ]; then
+        version=`cat "${GIT_ROOT}/VERSION.${plugin_type}.${plugin_name}" | tr -d ' ' | grep "foglamp_${plugin_type}_${plugin_name}_version" | head -1 | sed -e 's/\(.*\)=\(.*\)/\2/g'`
+        foglamp_version=`cat ${GIT_ROOT}/VERSION.${plugin_type}.${plugin_name} | tr -d ' ' | grep 'foglamp_version' | head -1 | sed -e 's/\(.*\)version\(.*\)/\2/g'`
+    else
+        echo Unable to determine version of package to create
+        rm -rf "${GIT_ROOT}"
+        exit 1
+    fi
 	echo Version is $version
     BUILD_ROOT="${GIT_ROOT}/packages/build"
     if [ "${plugin_package_name}" ]; then
@@ -131,9 +131,9 @@ do
     echo "The package will be built in                          : ${BUILD_ROOT}"
     echo "The package name is                                   : ${package_name}"
     if [ -f "${GIT_ROOT}/service_notification.version" ]; then
-	     service_notification_version=`cat ${GIT_ROOT}/service_notification.version | tr -d ' ' | grep 'service_notification_version' | head -1 | sed -e 's/\(.*\)version\([>=|>|<|<=|=]*\)\(.*\)/\2 \3/g'`
-	     echo "The Service notification required version        : ${service_notification_version}"
-	fi
+        service_notification_version=`cat ${GIT_ROOT}/service_notification.version | tr -d ' ' | grep 'service_notification_version' | head -1 | sed -e 's/\(.*\)version\(.*\)/\2/g'`
+        echo "The Service notification required version        : ${service_notification_version}"
+    fi
     echo
 
     # Create the package directory. If a directory with the same name exists,
@@ -155,20 +155,20 @@ do
     mkdir "${package_name}"
 
     # If plugin_type_install if not set use plugin_type value
-	if [ "${plugin_type}" = "notify" ]; then
-	    plugin_type_install="notificationDelivery"
+    if [ "${plugin_type}" = "notify" ]; then
+        plugin_type_install="notificationDelivery"
     elif [ "${plugin_type}" = "rule" ]; then
-	    plugin_type_install="notificationRule"
-	else
-	    plugin_type_install=${plugin_type}
-	fi
+        plugin_type_install="notificationRule"
+    else
+        plugin_type_install=${plugin_type}
+    fi
 
-	# Install directory path
-	if [ -d ${GIT_ROOT}/python ]; then
-	    installs=python/foglamp/plugins/${plugin_type_install}/${plugin_install_dirname}
-	else
-	    installs=plugins/${plugin_type_install}/${plugin_install_dirname}
-	fi
+    # Install directory path
+    if [ -d ${GIT_ROOT}/python ]; then
+        installs=python/foglamp/plugins/${plugin_type_install}/${plugin_install_dirname}
+    else
+        installs=plugins/${plugin_type_install}/${plugin_install_dirname}
+    fi
 
     # Populate the package directory with Debian files
     # First with files common to all plugins
@@ -179,33 +179,36 @@ do
     deb_path=${BUILD_ROOT}/${package_name}/DEBIAN
     cp -R ${PKG_ROOT}/packages/DEBIAN/* ${deb_path}
     sed -i "s/__VERSION__/${version}/g" ${deb_path}/control
-	sed -i "s/__NAME__/${pkg_name}/g" ${deb_path}/control
-	sed -i "s/__ARCH__/${archname}/g" ${deb_path}/control
-	sed -i "s/__REQUIRES__/${requirements}/g" ${deb_path}/control
-	sed -i "s/foglamp,/foglamp (${foglamp_version}),/" ${deb_path}/control
-	sed -i "s/foglamp$/foglamp (${foglamp_version})/" ${deb_path}/control
-	sed -i "s|__INSTALL_DIR__|${installs}|g" ${deb_path}/postinst
-	sed -i "s/__PLUGIN_NAME__/${plugin_name}/g" ${deb_path}/postinst
+    sed -i "s/__NAME__/${pkg_name}/g" ${deb_path}/control
+    sed -i "s/__ARCH__/${archname}/g" ${deb_path}/control
+    sed -i "s/__REQUIRES__/${requirements}/g" ${deb_path}/control
+    sed -i "s/foglamp,/foglamp (${foglamp_version}),/" ${deb_path}/control
+    sed -i "s/foglamp$/foglamp (${foglamp_version})/" ${deb_path}/control
+    sed -i "s|__INSTALL_DIR__|${installs}|g" ${deb_path}/postinst
+    sed -i "s/__PLUGIN_NAME__/${plugin_name}/g" ${deb_path}/postinst
     desc=`cat "${GIT_ROOT}/Description"`
     sed -i "s/__DESCRIPTION__/${desc}/g" ${deb_path}/control
+    if [ ! -z "${service_notification_version}" ] ; then
+        sed -i "s/foglamp-service-notification/foglamp-service-notification (${service_notification_version})/" ${deb_path}/control
+    fi
 
     # Creating packaging file structure
     mkdir -p usr/local/foglamp
     cd usr/local/foglamp
     if [ -d ${GIT_ROOT}/python ]; then
-		find ${GIT_ROOT}/python | grep -E "(__pycache__|\.pyc|\.pyo$)" | xargs rm -rf
-		cp -R ${GIT_ROOT}/python .
-		cp -R ${GIT_ROOT}/VERSION.${plugin_type}.${plugin_name} .
-	else
-		(cd ${GIT_ROOT};
-			if [ -f requirements.sh ]; then
-				./requirements.sh
-			fi
-			mkdir -p build; cd build; cmake ..; make)
-		mkdir -p "plugins/${plugin_type_install}/${plugin_install_dirname}"
-		cp -R --preserve=links ${GIT_ROOT}/build/lib* "plugins/${plugin_type_install}/${plugin_install_dirname}"
-	fi
-	echo "Done."
+        find ${GIT_ROOT}/python | grep -E "(__pycache__|\.pyc|\.pyo$)" | xargs rm -rf
+        cp -R ${GIT_ROOT}/python .
+        cp -R ${GIT_ROOT}/VERSION.${plugin_type}.${plugin_name} .
+    else
+        (cd ${GIT_ROOT};
+        if [ -f requirements.sh ]; then
+            ./requirements.sh
+        fi
+        mkdir -p build; cd build; cmake ..; make)
+        mkdir -p "plugins/${plugin_type_install}/${plugin_install_dirname}"
+        cp -R --preserve=links ${GIT_ROOT}/build/lib* "plugins/${plugin_type_install}/${plugin_install_dirname}"
+    fi
+    echo "Done."
 
     # Build the package
     cd "${BUILD_ROOT}"
@@ -226,10 +229,9 @@ do
 
     # Move final package to archive directory
     cp  ${BUILD_ROOT}/${package_name}.deb ${archive}/${arch}/${fullname}
-	cp -R ${BUILD_ROOT}/${package_name} ${archive}/${arch}/${fullname}
+    cp -R ${BUILD_ROOT}/${package_name} ${archive}/${arch}/${fullname}
 
     rm -rf /tmp/${REPO_NAME}
     exit 0
 done
 exit 0
-

--- a/plugins/make_deb
+++ b/plugins/make_deb
@@ -115,7 +115,7 @@ do
         rm -rf "${GIT_ROOT}"
         exit 1
     fi
-	echo Version is $version
+    echo Version is $version
     BUILD_ROOT="${GIT_ROOT}/packages/build"
     if [ "${plugin_package_name}" ]; then
         pkg_name=${plugin_package_name}
@@ -123,7 +123,8 @@ do
         pkg_name="foglamp-${plugin_type}-${plugin_name}"
     fi
     # Final package name
-    package_name="${pkg_name}-${version}"
+    archname=$(dpkg --print-architecture)
+    package_name="${pkg_name}-${version}-${archname}"
 
     # Print the summary of findings
     echo "The package root directory is                         : ${GIT_ROOT}"
@@ -132,7 +133,7 @@ do
     echo "The package name is                                   : ${package_name}"
     if [ -f "${GIT_ROOT}/service_notification.version" ]; then
         service_notification_version=`cat ${GIT_ROOT}/service_notification.version | tr -d ' ' | grep 'service_notification_version' | head -1 | sed -e 's/\(.*\)version\(.*\)/\2/g'`
-        echo "The Service notification required version        : ${service_notification_version}"
+        echo "The Service notification required version             : ${service_notification_version}"
     fi
     echo
 
@@ -175,7 +176,6 @@ do
     echo -n "Populating the package and updating version file..."
     cd "${package_name}"
     mkdir DEBIAN
-    archname=$(dpkg --print-architecture)
     deb_path=${BUILD_ROOT}/${package_name}/DEBIAN
     cp -R ${PKG_ROOT}/packages/DEBIAN/* ${deb_path}
     sed -i "s/__VERSION__/${version}/g" ${deb_path}/control

--- a/plugins/make_rpm
+++ b/plugins/make_rpm
@@ -53,7 +53,7 @@ while getopts ":hcab:" opt; do
 			exit 0
 			;;
 		h)
-			echo ${usage}
+			echo "${usage}"
 			exit 0
 			;;
 		b)

--- a/plugins/packages/DEBIAN/control
+++ b/plugins/packages/DEBIAN/control
@@ -1,0 +1,10 @@
+Package: __NAME__
+Version: __VERSION__
+Section: devel
+Priority: optional
+Architecture: __ARCH__
+Depends: __REQUIRES__
+Conflicts:
+Maintainer: Dianomic Systems, Inc. <info@dianomic.com>
+Homepage: http://www.dianomic.com
+Description: __DESCRIPTION__

--- a/plugins/packages/DEBIAN/postinst
+++ b/plugins/packages/DEBIAN/postinst
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+##--------------------------------------------------------------------
+## Copyright (c) 2019 Dianomic Systems Inc.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##--------------------------------------------------------------------
+
+##--------------------------------------------------------------------
+##
+## @postinst DEBIAN/postinst
+## This script is used to execute post installation tasks.
+##
+## Author: Ashish Jabble
+##
+##--------------------------------------------------------------------
+
+set -e
+
+set_files_ownership () {
+    chown -R root:root /usr/local/foglamp/__INSTALL_DIR__
+}
+
+set_files_ownership
+echo __PLUGIN_NAME__ plugin is installed.
+
+# Install Python dependencies when requirements file exists
+if [ -f /usr/local/foglamp/python/requirements-__PLUGIN_NAME__.txt ]; then
+    pip3 install -Ir /usr/local/foglamp/python/requirements-__PLUGIN_NAME__.txt
+fi


### PR DESCRIPTION
I ran custom CI-JOB [here](http://jenkins.dianomic.com:8080/job/foglamp_debian_packaging_ub1804_test/3/artifact/reports/result.csv/*view*/) and make_deb passes for all plugins except the **foglamp-south-mqtt-sparkplug**.

dpkg build error fails as it has special characters like "underscore" in package name. So this has also been fixed but at repo side [here](https://github.com/foglamp/foglamp-south-mqtt-sparkplug/pull/11). 
If we want to override the package name we will use this variable in Package file.

**Other items:**
1) README.rst for plugins added
2) make_plugin_rpm script renamed  to make_rpm (as we executed the script inside plugins dir)