### PR TITLE
FOGL-2858: Include JSON files in deb/rpm package in case of hybrid plugins

### DIFF
--- a/plugins/make_deb
+++ b/plugins/make_deb
@@ -206,7 +206,9 @@ do
         fi
         mkdir -p build; cd build; cmake ..; make)
         mkdir -p "plugins/${plugin_type_install}/${plugin_install_dirname}"
-        cp -R --preserve=links ${GIT_ROOT}/build/lib* "plugins/${plugin_type_install}/${plugin_install_dirname}"
+        cp -R --preserve=links ${GIT_ROOT}/build/lib* "plugins/${plugin_type_install}/${plugin_install_dirname}" 2>/dev/null || \
+        cp -R --preserve=links ${GIT_ROOT}/*.json "plugins/${plugin_type_install}/${plugin_install_dirname}" 2>/dev/null || \
+        echo "Unable to find libraries in ${GIT_ROOT}/build and json config files in ${GIT_ROOT}, cannot proceed..."
     fi
     echo "Done."
 

--- a/plugins/make_rpm
+++ b/plugins/make_rpm
@@ -228,7 +228,10 @@ EOF
 				mkdir -p build; cd build; cmake ..; make
 			fi)
 		mkdir -p "plugins/${plugin_type_install}/${plugin_install_dirname}"
-		cp -R --preserve=links ${GIT_ROOT}/build/lib* "plugins/${plugin_type_install}/${plugin_install_dirname}"
+	        cp -R --preserve=links ${GIT_ROOT}/build/lib* "plugins/${plugin_type_install}/${plugin_install_dirname}" 2>/dev/null || \
+        	cp -R --preserve=links ${GIT_ROOT}/*.json "plugins/${plugin_type_install}/${plugin_install_dirname}" 2>/dev/null || \
+        	echo "Unable to find libraries in ${GIT_ROOT}/build and json config files in ${GIT_ROOT}, cannot proceed..."
+
 	fi
 	echo "Done."
 


### PR DESCRIPTION
This change is required for including just the JSON files in debian/rpm package in case of hybrid plugin.