### PR TITLE
FOGL-2887 requirements.sh copied for python plugins if exists 

### DIFF
--- a/plugins/make_deb
+++ b/plugins/make_deb
@@ -199,10 +199,10 @@ do
         find ${GIT_ROOT}/python | grep -E "(__pycache__|\.pyc|\.pyo$)" | xargs rm -rf
         if [ -f "${GIT_ROOT}/requirements.sh" ]; then
             sed -i "s/sudo//" ${GIT_ROOT}/requirements.sh
-            cp -R ${GIT_ROOT}/requirements.sh ${GIT_ROOT}/python/requirements-${plugin_name}.sh
+            cp -p ${GIT_ROOT}/requirements.sh ${GIT_ROOT}/python/requirements-${plugin_name}.sh
         fi
         cp -R ${GIT_ROOT}/python .
-        cp -R ${GIT_ROOT}/VERSION.${plugin_type}.${plugin_name} .
+        cp -R ${GIT_ROOT}/VERSION.${plugin_type}.${plugin_name} ./python/foglamp/plugins/${plugin_type}/${plugin_name}
     else
         (cd ${GIT_ROOT};
         if [ -f requirements.sh ]; then

--- a/plugins/make_deb
+++ b/plugins/make_deb
@@ -197,6 +197,10 @@ do
     cd usr/local/foglamp
     if [ -d ${GIT_ROOT}/python ]; then
         find ${GIT_ROOT}/python | grep -E "(__pycache__|\.pyc|\.pyo$)" | xargs rm -rf
+        if [ -f "${GIT_ROOT}/requirements.sh" ]; then
+            sed -i "s/sudo//" ${GIT_ROOT}/requirements.sh
+            cp -R ${GIT_ROOT}/requirements.sh ${GIT_ROOT}/python/requirements-${plugin_name}.sh
+        fi
         cp -R ${GIT_ROOT}/python .
         cp -R ${GIT_ROOT}/VERSION.${plugin_type}.${plugin_name} .
     else

--- a/plugins/make_rpm
+++ b/plugins/make_rpm
@@ -215,8 +215,13 @@ EOF
 	mkdir -p usr/local/foglamp
 	cd usr/local/foglamp
 	if [ -d ${GIT_ROOT}/python ]; then
-		find ${GIT_ROOT}/python | grep -E "(__pycache__|\.pyc|\.pyo$)" | xargs rm -rf
-		cp -R ${GIT_ROOT}/python .
+	    find ${GIT_ROOT}/python | grep -E "(__pycache__|\.pyc|\.pyo$)" | xargs rm -rf
+	    if [ -f "${GIT_ROOT}/requirements.sh" ]; then
+	        sed -i "s/sudo//" ${GIT_ROOT}/requirements.sh
+	        cp -p ${GIT_ROOT}/requirements.sh ${GIT_ROOT}/python/requirements-${plugin_name}.sh
+	    fi
+	    cp -R ${GIT_ROOT}/python .
+	    cp -R ${GIT_ROOT}/VERSION.${plugin_type}.${plugin_name} ./python/foglamp/plugins/${plugin_type}/${plugin_name}
 	else
 		(cd ${GIT_ROOT}; 
 			if [ -f requirements.sh ]; then

--- a/plugins/packages/DEBIAN/postinst
+++ b/plugins/packages/DEBIAN/postinst
@@ -32,9 +32,15 @@ set_files_ownership () {
 }
 
 set_files_ownership
-echo __PLUGIN_NAME__ plugin is installed.
 
-# Install Python dependencies when requirements file exists
+# Install Prerequisite; if any
+if [ -f /usr/local/foglamp/python/requirements-__PLUGIN_NAME__.sh ]; then
+   sh /usr/local/foglamp/python/requirements-__PLUGIN_NAME__.sh
+fi
+
+# Install Python dependencies; if any
 if [ -f /usr/local/foglamp/python/requirements-__PLUGIN_NAME__.txt ]; then
     pip3 install -Ir /usr/local/foglamp/python/requirements-__PLUGIN_NAME__.txt
 fi
+
+echo __PLUGIN_NAME__ plugin is installed.

--- a/plugins/packages/RPM/SPECS/plugin.spec
+++ b/plugins/packages/RPM/SPECS/plugin.spec
@@ -121,6 +121,11 @@ set_files_ownership () {
 echo "Setting ownership of FogLAMP files"
 set_files_ownership
 
+# Install Prerequisite; if any
+if [ -f /usr/local/foglamp/python/requirements-__PLUGIN_NAME__.sh ]; then
+   sh /usr/local/foglamp/python/requirements-__PLUGIN_NAME__.sh
+fi
+
 # Install any Python dependencies
 if [ -f /usr/local/foglamp/python/requirements-__PLUGIN_NAME__.txt ]; then
 	bash << EOF


### PR DESCRIPTION
Also fixed - `VERSION.${plugin_type}.${plugin_name}` copied to `/python/foglamp/plugins/${plugin_type}/${plugin_name}`