### PR TITLE
FOGL-2913 make deb package name fixes as per arch

### DIFF
--- a/plugins/make_deb
+++ b/plugins/make_deb
@@ -124,7 +124,7 @@ do
     fi
     # Final package name
     archname=$(dpkg --print-architecture)
-    package_name="${pkg_name}-${version}-${archname}"
+    package_name="${pkg_name}-${version}-${arch}"
 
     # Print the summary of findings
     echo "The package root directory is                         : ${GIT_ROOT}"


### PR DESCRIPTION
```
$ ls archive/DEBIAN/x86_64/foglamp-
foglamp-north-http-1.6.0-x86_64/     foglamp-south-http-1.6.0-x86_64/     
foglamp-north-http-1.6.0-x86_64.deb  foglamp-south-http-1.6.0-x86_64.deb
```