### PR TITLE
consistency package name fixes for armhf architecture

### DIFF
--- a/plugins/make_deb
+++ b/plugins/make_deb
@@ -72,6 +72,9 @@ while [ "${REPO_NAME}" != "" ]
 do
 	package_manager=deb
 	arch=`arch`
+    if [ "${arch}" = "armv7l" ]; then
+        arch="armhf"
+    fi
 	archive=`pwd`/archive/DEBIAN
 	if [ ! -d "${archive}/${arch}" ]; then
 		mkdir -p "${archive}/${arch}"


### PR DESCRIPTION
http://jenkins.dianomic.com:8080/view/Packaging/job/foglamp_debian_packaging_arm/195/artifact/artifacts/

`armv7l Vs armhf`

**Plugins**
```
pi@raspberrypi:~/foglamp-pkg/plugins $ ls archive/DEBIAN/armhf
foglamp-north-http-1.6.0-armhf  foglamp-north-http-1.6.0-armhf.deb  foglamp-south-sinusoid-1.6.0-armhf  foglamp-south-sinusoid-1.6.0-armhf.deb

```