### PR TITLE
FOGL-2991 python3-dev dep added in x86_64 arch as it requires for FOGL-2991

### DIFF
--- a/packages/Debian/x86_64/DEBIAN/control
+++ b/packages/Debian/x86_64/DEBIAN/control
@@ -3,7 +3,7 @@ Version: 1.0.0
 Section: devel
 Priority: optional
 Architecture: amd64
-Depends: autoconf,curl,libtool,libboost-dev,libboost-system-dev,libboost-thread-dev,libpq-dev,python3-pip,python3-setuptools,sqlite3,sudo
+Depends: autoconf,curl,libtool,libboost-dev,libboost-system-dev,libboost-thread-dev,libpq-dev,python3-dev,python3-pip,python3-setuptools,sqlite3,sudo
 Conflicts:
 Maintainer: Dianomic Systems, Inc. <info@dianomic.com>
 Homepage: http://www.dianomic.com


### PR DESCRIPTION
Problem is solved by adding `python3-dev` mentioned in FOGL-2991.
As this problem we found for `ub16.04` Only when we run both GUI and foglamp packages simultaneously. So made changes only for `x86_64` architecture.

Have tested at my end on both ub16 and ub18 fresh environment.