### PR TITLE
FOGL-3090 install notes added for make_deb plugins

### DIFF
--- a/plugins/make_deb
+++ b/plugins/make_deb
@@ -191,6 +191,21 @@ do
     if [ ! -z "${service_notification_version}" ] ; then
         sed -i "s/foglamp-service-notification/foglamp-service-notification (${service_notification_version})/" ${deb_path}/control
     fi
+    # install notes
+    if [ -f "${GIT_ROOT}/install_notes.txt" ]; then
+        cat > /tmp/sed.script.$$ << EOF
+	    /__PLUGIN_NOTES__/ {
+		    r ${GIT_ROOT}/install_notes.txt
+		    d
+	    }
+EOF
+	sed -i -f /tmp/sed.script.$$ ${deb_path}/postinst
+	rm /tmp/sed.script.$$
+    else
+        sed -i "s/echo \"/""/g" ${deb_path}/postinst
+        sed -i "s/__PLUGIN_NOTES__/""/g" ${deb_path}/postinst
+        sed -i "s/\"/""/g" ${deb_path}/postinst
+    fi
 
     # Creating packaging file structure
     mkdir -p usr/local/foglamp

--- a/plugins/packages/DEBIAN/postinst
+++ b/plugins/packages/DEBIAN/postinst
@@ -44,3 +44,6 @@ if [ -f /usr/local/foglamp/python/requirements-__PLUGIN_NAME__.txt ]; then
 fi
 
 echo __PLUGIN_NAME__ plugin is installed.
+echo "
+__PLUGIN_NOTES__
+"


### PR DESCRIPTION
Related PR's
- [x] https://github.com/foglamp/foglamp-south-envirophat/pull/29
- [x] https://github.com/foglamp/foglamp-south-game/pull/21
- [x] https://github.com/foglamp/foglamp-south-sensehat/pull/20

See the `install notes` at the end of logs

```
pi@raspberrypi:~ $ sudo apt install -y ./foglamp-south-envirophat-1.6.0-armv7l.deb 
Reading package lists... Done
Building dependency tree       
Reading state information... Done
Note, selecting 'foglamp-south-envirophat' instead of './foglamp-south-envirophat-1.6.0-armv7l.deb'
The following package was automatically installed and is no longer required:
  rpi.gpio-common
Use 'sudo apt autoremove' to remove it.
The following NEW packages will be installed:
  foglamp-south-envirophat
0 upgraded, 1 newly installed, 0 to remove and 0 not upgraded.
Need to get 0 B/3692 B of archives.
After this operation, 0 B of additional disk space will be used.
Get:1 /home/pi/foglamp-south-envirophat-1.6.0-armv7l.deb foglamp-south-envirophat armhf 1.6.0 [3692 B]
perl: warning: Setting locale failed.        
perl: warning: Please check that your locale settings:
	LANGUAGE = (unset),
	LC_ALL = (unset),
	LC_CTYPE = "UTF-8",
	LANG = "en_GB.UTF-8"
    are supported and installed on your system.
perl: warning: Falling back to a fallback locale ("en_GB.UTF-8").
locale: Cannot set LC_CTYPE to default locale: No such file or directory
locale: Cannot set LC_ALL to default locale: No such file or directory
Selecting previously unselected package foglamp-south-envirophat.
(Reading database ... 56766 files and directories currently installed.)
Preparing to unpack .../foglamp-south-envirophat-1.6.0-armv7l.deb ...
Unpacking foglamp-south-envirophat (1.6.0) ...
Setting up foglamp-south-envirophat (1.6.0) ...
envirophat plugin is installed.

It is required to enable I2C on the RPi, please do the following steps:

1) sudo raspi-config
2) Choose Interfacing options
3) Choose P5I2C option Enable/Disable automatic loading of I2C Kernel module
4) Follow the prompt to set Yes for ARM I2C interface enabled
5) Once that's done, reboot your RPi to let the changes propagate.
6) And be ensure that your I2C is enabled, run command ls /dev/*i2c*
```