### PR TITLE
FOGL-3288 preserve links of libbiodaq added for south usb4704 plugin as a special case in centralised debian package file

### DIFF
--- a/plugins/make_deb
+++ b/plugins/make_deb
@@ -230,6 +230,12 @@ EOF
         cp -R --preserve=links ${GIT_ROOT}/build/lib* "plugins/${plugin_type_install}/${plugin_install_dirname}" 2>/dev/null || \
         cp -R --preserve=links ${GIT_ROOT}/*.json "plugins/${plugin_type_install}/${plugin_install_dirname}" 2>/dev/null || \
         echo "Unable to find libraries in ${GIT_ROOT}/build and json config files in ${GIT_ROOT}, cannot proceed..."
+        # Special Case for ubs4704 south plugin
+        if [ "${plugin_name}" = "usb4704" ]; then
+            cd -
+            mkdir -p usr/lib
+            cp -R --preserve=links /usr/lib/libbiodaq* usr/lib
+        fi
     fi
     echo "Done."
 


### PR DESCRIPTION
```
$ sudo dpkg -c plugins/archive/DEBIAN/x86_64/foglamp-south-usb4704-1.7.0-x86_64.deb 
drwxrwxr-x foglamp/foglamp   0 2019-09-25 12:18 ./
drwxrwxr-x foglamp/foglamp   0 2019-09-25 12:18 ./usr/
drwxrwxr-x foglamp/foglamp   0 2019-09-25 12:18 ./usr/lib/
-rw-r--r-- foglamp/foglamp 1103315 2019-09-25 12:18 ./usr/lib/libbiodaqutil.so
-rw-r--r-- foglamp/foglamp   16 2019-09-25 12:18 ./usr/lib/libbiodaqutil.so.4.0.0.0
-rw-r--r-- foglamp/foglamp 1885546 2019-09-25 12:18 ./usr/lib/libbiodaq.so
-rw-r--r-- foglamp/foglamp   12 2019-09-25 12:18 ./usr/lib/libbiodaq.so.4.0.0.0
drwxrwxr-x foglamp/foglamp   0 2019-09-25 12:18 ./usr/local/
drwxrwxr-x foglamp/foglamp   0 2019-09-25 12:18 ./usr/local/foglamp/
drwxrwxr-x foglamp/foglamp   0 2019-09-25 12:18 ./usr/local/foglamp/plugins/
drwxrwxr-x foglamp/foglamp   0 2019-09-25 12:18 ./usr/local/foglamp/plugins/south/
drwxrwxr-x foglamp/foglamp   0 2019-09-25 12:18 ./usr/local/foglamp/plugins/south/usb4704/
-rwxrwxr-x foglamp/foglamp 86688 2019-09-25 12:18 ./usr/local/foglamp/plugins/south/usb4704/libusb4704.so.1
lrwxrwxrwx foglamp/foglamp   0 2019-09-25 12:18 ./usr/local/foglamp/plugins/south/usb4704/libusb4704.so -> libusb4704.so.1
```

Verified its discovery and installation  on Ubuntu1804
[foglamp-south-usb4704.zip](https://github.com/foglamp/foglamp-pkg/files/3651216/foglamp-south-usb4704.zip)
