### PR TITLE
FOGL-3366 | FOGL-3385 removed warnings from package installation

### DIFF
--- a/packages/Debian/common/DEBIAN/postinst
+++ b/packages/Debian/common/DEBIAN/postinst
@@ -151,7 +151,7 @@ echo "Calling FogLAMP package update script"
 call_package_update_script
 echo "Linking update task"
 link_update_task
-echo "Copying sodoers file"
+echo "Copying sudoers file"
 copy_foglamp_sudoer_file
 echo "Setting setuid bit of cmdutil"
 setuid_cmdutil

--- a/packages/Debian/common/DEBIAN/postrm
+++ b/packages/Debian/common/DEBIAN/postrm
@@ -27,9 +27,16 @@
 
 set -e
 
+remove_unused_files () {
+  find /usr/local/foglamp/ -maxdepth 1 -mindepth 1 -type d | egrep -v -w '(/usr/local/foglamp/data)' | xargs rm -rf
+}
+
 remove_foglamp_sudoer_file() {
     rm -rf /etc/sudoers.d/foglamp
 }
+
+echo "Cleanup of files"
+remove_unused_files
 
 echo "Remove foglamp sudoers file"
 remove_foglamp_sudoer_file

--- a/packages/Debian/common/DEBIAN/prerm
+++ b/packages/Debian/common/DEBIAN/prerm
@@ -67,17 +67,6 @@ reset_systemctl () {
     systemctl reset-failed
 }
 
-remove_pycache_files () {
-    set +e
-    find /usr/local/foglamp -name "*.pyc" -exec rm -rf {} \;
-    find /usr/local/foglamp -name "__pycache__" -exec rm -rf {} \;
-    set -e
-}
-
-remove_data_files () {
-    rm -rf /usr/local/foglamp/data
-}
-
 # main
 
 IS_FOGLAMP_RUNNING=$(is_foglamp_running)
@@ -90,10 +79,6 @@ then
     kill_foglamp
 fi
 
-#echo "Remove data directory."
-#remove_data_files
-echo "Remove python cache files."
-remove_pycache_files
 echo "Disable FogLAMP service."
 disable_foglamp_service
 echo "Remove FogLAMP service script"

--- a/packages/RPM/SPECS/foglamp.spec
+++ b/packages/RPM/SPECS/foglamp.spec
@@ -201,18 +201,6 @@ reset_systemctl () {
     systemctl reset-failed
 }
 
-remove_pycache_files () {
-    set +e
-    find /usr/local/foglamp -name "*.pyc" -exec rm -rf {} \;
-    find /usr/local/foglamp -name "__pycache__" -exec rm -rf {} \;
-    set -e
-}
-
-remove_data_files () {
-	rm -rf /usr/local/foglamp/data
-
-}
-
 # main
 
 IS_FOGLAMP_RUNNING=$(is_foglamp_running)
@@ -226,10 +214,6 @@ then
     kill_foglamp
 fi
 
-#echo "Remove data directory."
-#remove_data_files
-echo "Remove python cache files."
-remove_pycache_files
 echo "Disable FogLAMP service."
 disable_foglamp_service
 echo "Remove FogLAMP service script"
@@ -421,7 +405,7 @@ set_files_ownership
 #echo "Linking update task"
 #link_update_task
 
-echo "Copying sodoers file"
+echo "Copying sudoers file"
 copy_foglamp_sudoer_file
 
 echo "Enabling FogLAMP service"
@@ -460,9 +444,16 @@ start_foglamp_service
 
 set -e
 
+remove_unused_files () {
+  find /usr/local/foglamp/ -maxdepth 1 -mindepth 1 -type d | egrep -v -w '(/usr/local/foglamp/data)' | xargs rm -rf
+}
+
 remove_foglamp_sudoer_file() {
     rm -rf /etc/sudoers.d/foglamp
 }
+
+echo "Cleanup of files"
+remove_unused_files
 
 echo "Remove foglamp sudoers file"
 remove_foglamp_sudoer_file


### PR DESCRIPTION
Purge O/P for debian

```
 foglamp*
0 upgraded, 0 newly installed, 1 to remove and 21 not upgraded.
After this operation, 0 B of additional disk space will be used.
(Reading database ... 56787 files and directories currently installed.)
Removing foglamp (1.7.0) ...
FogLAMP is currently running.
Stop FogLAMP service.
Kill FogLAMP.
Disable FogLAMP service.
foglamp.service is not a native service, redirecting to systemd-sysv-install.
Executing: /lib/systemd/systemd-sysv-install disable foglamp
Remove FogLAMP service script
Reset systemctl
Cleanup of files
Remove foglamp sudoers file
(Reading database ... 56374 files and directories currently installed.)
Purging configuration files for foglamp (1.7.0) ...
Cleanup of files
Remove foglamp sudoers file
dpkg: warning: while removing foglamp, directory '/usr/local/foglamp' not empty so not removed
```

Now Only 1 warning is there and that is expected as we donot remove the **data** directory from foglamp